### PR TITLE
Add initial method implementation for system interface access.

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -1,0 +1,77 @@
+name: Go
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+  schedule:
+    - cron: "0 0 * * *"
+
+jobs:
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        go: ['1.18', '1.x']
+    steps:
+
+    - name: Set up Go ${{ matrix.go }}
+      uses: actions/setup-go@v2
+      with:
+        go-version: ${{ matrix.go }}
+      id: go
+
+    - name: Check out code into the Go module directory
+      uses: actions/checkout@v2
+
+    - name: Get dependencies
+      run: |
+        go get -v -t -d ./...
+
+    - name: Build
+      run: go build -v ./...
+
+    - name: Test
+      run: go test -v -coverprofile=profile.cov ./...
+
+    - name: Race Test
+      run: |
+          go test -race ./...
+
+    - name: Coveralls
+      if: ${{ matrix.go == '1.x' }}
+      uses: shogo82148/actions-goveralls@v1
+      with:
+        path-to-profile: profile.cov
+
+  static_analysis:
+    name: Static Analysis
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Install Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: '1.x'
+        id: go
+
+      - name: Install required static analysis tools
+        run: |
+          go install honnef.co/go/tools/cmd/staticcheck@latest
+
+      - name: Check out code
+        uses: actions/checkout@v2
+
+      - name: Get dependencies
+        run: go get -v -t -d ./...
+
+      - name: Go vet
+        run: go vet ./...
+
+      - name: Check gofmt
+        run: diff -u <(echo -n) <(gofmt -d -s .)
+
+      - name: Staticcheck
+        run: |
+          staticcheck ./...

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,10 @@
 module github.com/openconfig/magna
 
-go 1.16
+go 1.18
 
 require github.com/vishvananda/netlink v1.1.0
+
+require (
+	github.com/vishvananda/netns v0.0.0-20191106174202-0a2b9b5464df // indirect
+	golang.org/x/sys v0.0.0-20190606203320-7fc4e5ec1444 // indirect
+)

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,5 @@
+module github.com/openconfig/magna
+
+go 1.16
+
+require github.com/vishvananda/netlink v1.1.0

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,6 @@
+github.com/vishvananda/netlink v1.1.0 h1:1iyaYNBLmP6L0220aDnYQpo1QEV4t4hJ+xEEhhJH8j0=
+github.com/vishvananda/netlink v1.1.0/go.mod h1:cTgwzPIzzgDAYoQrMm0EdrjRUBkTqKYppBueQtXaqoE=
+github.com/vishvananda/netns v0.0.0-20191106174202-0a2b9b5464df h1:OviZH7qLw/7ZovXvuNyL3XQl8UFofeikI1NW1Gypu7k=
+github.com/vishvananda/netns v0.0.0-20191106174202-0a2b9b5464df/go.mod h1:JP3t17pCcGlemwknint6hfoeCVQrEMVwxRLRjXpq+BU=
+golang.org/x/sys v0.0.0-20190606203320-7fc4e5ec1444 h1:/d2cWp6PSamH4jDPFLyO150psQdqvtoNX8Zjg3AQ31g=
+golang.org/x/sys v0.0.0-20190606203320-7fc4e5ec1444/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=

--- a/intf/accessor_linux.go
+++ b/intf/accessor_linux.go
@@ -1,0 +1,86 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package intf
+
+import (
+	"fmt"
+	"net"
+
+	"github.com/vishvananda/netlink"
+)
+
+func init() {
+	// On init when the package has been built on Linux, load the netlink
+	// accessor as the implementation to be used.
+	//
+	// TODO(robjs): Consider whether we should use build tags vs. solely
+	// the underlying system, since this would allow a build tag to say
+	// that the package should use gRPC wire.
+	accessor = netlinkAccessor{}
+}
+
+// netlinkAccessor implements the NetworkAccessor interface for a Linux
+// system.
+type netlinkAccessor struct {
+	unimplementedAccessor
+}
+
+// Interface retrieves the interface named from the underlying system
+// through making a netlink call.
+func (n netlinkAccessor) Interface(name string) (*Interface, error) {
+	link, err := netlink.LinkByName(name)
+	if err != nil {
+		return nil, fmt.Errorf("cannot get interface, %v", err)
+	}
+
+	attrs := link.Attrs()
+	return &Interface{
+		Index: attrs.Index,
+		Name:  attrs.Name,
+		MAC:   attrs.HardwareAddr,
+	}, nil
+}
+
+// InterfaceAddresses retrieves the set of addresses that are configured on interface
+// name. It returns the addresses as a set of net.IPNet structs including the address
+// and mask of each interface.
+func (n netlinkAccessor) InterfaceAddresses(name string) ([]*net.IPNet, error) {
+	link, err := netlink.LinkByName(name)
+	if err != nil {
+		return nil, fmt.Errorf("cannot get interface, %v", err)
+	}
+	addrs, err := netlink.AddrList(link, 0)
+	if err != nil {
+		return nil, fmt.Errorf("cannot retrieve interface %s addresses, %v", name, err)
+	}
+
+	nets := []*net.IPNet{}
+	for _, a := range addrs {
+		nets = append(nets, a.IPNet)
+	}
+	return nets, nil
+}
+
+// InterfaceAddIP adds the address addr to the interface name using netlink.
+func (n netlinkAccessor) InterfaceAddIP(name string, addr *net.IPNet) error {
+	link, err := netlink.LinkByName(name)
+	if err != nil {
+		return fmt.Errorf("cannot get interface, %v", err)
+	}
+	if err := netlink.AddrAdd(link, &netlink.Addr{IPNet: addr}); err != nil {
+		return fmt.Errorf("cannot add IP address to interface %s, %v", name, err)
+	}
+	return nil
+}

--- a/intf/accessor_linux.go
+++ b/intf/accessor_linux.go
@@ -42,7 +42,7 @@ type netlinkAccessor struct {
 func (n netlinkAccessor) Interface(name string) (*Interface, error) {
 	link, err := netlink.LinkByName(name)
 	if err != nil {
-		return nil, fmt.Errorf("cannot get interface, %v", err)
+		return nil, fmt.Errorf("cannot get interface %s, %v", name, err)
 	}
 
 	attrs := link.Attrs()

--- a/intf/intf.go
+++ b/intf/intf.go
@@ -70,13 +70,13 @@ type ARPUpdate struct {
 // to use the functions within this package whilst using a different underlying
 // implementation (e.g., netlink on Linux to access the kernel).
 type NetworkAccessor interface {
-	// Links returns a set of links that are present on the local system.
+	// Interfaces returns a set of interfaces that are present on the local system.
 	Interfaces() ([]*Interface, error)
-	// Link retrieves the link with the specified name.
+	// Interface retrieves the interface with the specified name.
 	Interface(name string) (*Interface, error)
-	// AddressList lists the IP addresses configured on a particular interface.
+	// InterfaceAdddresses lists the IP addresses configured on a particular interface.
 	InterfaceAddresses(name string) ([]*net.IPNet, error)
-	// AddressAdd adds address ip to the interface name.
+	// AddInterfaceIP adds address ip to the interface name.
 	AddInterfaceIP(name string, ip *net.IPNet) error
 	// ARPList lists the set of ARP neighbours on the system.
 	ARPList() ([]*ARPEntry, error)

--- a/intf/intf.go
+++ b/intf/intf.go
@@ -1,0 +1,156 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package intf implements mechanisms to access underlying interfaces in
+// a manner that is agnostic to the underlying implementation. An implementation
+// is included that uses netlink to write to a Linux kernl implementation.
+// Additional implementations can be provided to allow writing to e.g. a
+// gRPCwire implementation.
+package intf
+
+import (
+	"fmt"
+	"net"
+)
+
+// Link represents information corresponding to a single interface on the
+// underlying system.
+type Interface struct {
+	// Index is an integer index used to refer to the interface.
+	Index int
+	// Name is the name used to refer to the interface in the system.
+	Name string
+	// MAC is the MAC address of the interface.
+	MAC net.HardwareAddr
+}
+
+// ARPNeigh is a representation of an ARP entry on the underlying system.
+type ARPNeigh struct {
+	// IP is the IP address of the neighbour.
+	IP net.IP
+	// Interface is the name of the interface on which the ARP entry was learnt.
+	Interface string
+	// MAC is the MAC address of the neighbour.
+	MAC net.HardwareAddr
+}
+
+// ARPEvent is used to describe a particular event on the ARP table.
+type ARPEvent int64
+
+const (
+	// ARPUnknown is used when the event is not an add or delete.
+	ARPUnknown ARPEvent = iota
+	// ARPAdd indicates that the ARP neighbour was added.
+	ARPAdd
+	// ARPDelete inidcates that the ARP neighbour was deleted.
+	ARPDelete
+)
+
+// ARPUpdate is used to describe a change to the ARP table.
+type ARPUpdate struct {
+	// Type indicates whether the event was an add or delete.
+	Type ARPEvent
+	// Neigh is the neighbour that the change corresponds to
+	Neigh ARPNeigh
+}
+
+// NetworkAccessor is an interface implemented by the underlying system access
+// interface. Through implementing the NetworkAccessor interface it is possible
+// to use the functions within this package whilst using a different underlying
+// implementation (e.g., netlink on Linux to access the kernel).
+type NetworkAccessor interface {
+	// Links returns a set of links that are present on the local system.
+	Interfaces() ([]*Interface, error)
+	// Link retrieves the link with the specified name.
+	Interface(name string) (*Interface, error)
+	// AddressList lists the IP addresses configured on a particular interface.
+	InterfaceAddresses(name string) ([]*net.IPNet, error)
+	// AddressAdd adds address ip to the interface name.
+	AddInterfaceIP(name string, ip *net.IPNet) error
+	// ARPList lists the set of ARP neighbours on the system.
+	ARPList() ([]*ARPNeigh, error)
+	// ARPSubscribe writes changes to the ARP table to the channel updates, and uses
+	// done to indicate that the subscription is complete.
+	ARPSubscribe(updates chan ARPUpdate, done chan struct{}) error
+}
+
+// unimplementedAccessor is an accessor interface that returns unimplemented
+// for all underlying methods.
+type unimplementedAccessor struct{}
+
+// Interface returns unimplemented for the interface call.
+func (u unimplementedAccessor) Interface(_ string) (*Interface, error) {
+	return nil, fmt.Errorf("unimplemented")
+}
+
+// Interfaces returns unimplemented when asked to list interfaces.
+func (n unimplementedAccessor) Interfaces() ([]*Interface, error) {
+	return nil, fmt.Errorf("unimplemented")
+}
+
+// InterfaceAddresses returns unimplemented when asked for list IP addresses.
+func (n unimplementedAccessor) InterfaceAddresses(_ string) ([]*net.IPNet, error) {
+	return nil, fmt.Errorf("unimplemented")
+}
+
+// AddInterfaceIP returns unimplemented when asked to add an interface.
+func (n unimplementedAccessor) AddInterfaceIP(_ string, _ *net.IPNet) error {
+	return fmt.Errorf("unimplemented")
+}
+
+// ARPList returns unimplemented when asked to list ARP entries.
+func (n unimplementedAccessor) ARPList() ([]*ARPNeigh, error) {
+	return nil, fmt.Errorf("unimplemented")
+}
+
+// ARPSubscribe returns unimplemented when asked to subscribe to ARP changes.
+func (n unimplementedAccessor) ARPSubscribe(_ chan ARPUpdate, _ chan struct{}) error {
+	return fmt.Errorf("unimplemented")
+}
+
+// accessor is the implementation of the network accessor that should be used. It
+// should be set by init() [which may be a platform-specific initiation].
+var accessor NetworkAccessor
+
+// ValidInterface determines whether the interface name is valid for the
+// current system.
+func ValidInterface(name string) bool {
+	if accessor == nil {
+		panic("accessor was nil, this package was not built on a supported system.")
+	}
+	if _, err := accessor.Interface(name); err != nil {
+		return false
+	}
+	return true
+}
+
+// AddIP adds an IP address addr to the interface intf.
+func AddIP(intf string, addr *net.IPNet) error {
+	addrs, err := accessor.InterfaceAddresses(intf)
+	if err != nil {
+		return err
+	}
+
+	for _, a := range addrs {
+		if a.IP.Equal(addr.IP) {
+			return nil // already configured.
+		}
+	}
+
+	// Configure the address.
+	if err := accessor.AddInterfaceIP(intf, addr); err != nil {
+		return fmt.Errorf("cannot add address, %v", err)
+	}
+	return nil
+}

--- a/intf/intf.go
+++ b/intf/intf.go
@@ -79,7 +79,7 @@ type NetworkAccessor interface {
 	// AddressAdd adds address ip to the interface name.
 	AddInterfaceIP(name string, ip *net.IPNet) error
 	// ARPList lists the set of ARP neighbours on the system.
-	ARPList() ([]*ARPNeigh, error)
+	ARPList() ([]*ARPEntry, error)
 	// ARPSubscribe writes changes to the ARP table to the channel updates, and uses
 	// done to indicate that the subscription is complete.
 	ARPSubscribe(updates chan ARPUpdate, done chan struct{}) error
@@ -110,7 +110,7 @@ func (u unimplementedAccessor) AddInterfaceIP(_ string, _ *net.IPNet) error {
 }
 
 // ARPList returns unimplemented when asked to list ARP entries.
-func (u unimplementedAccessor) ARPList() ([]*ARPNeigh, error) {
+func (u unimplementedAccessor) ARPList() ([]*ARPEntry, error) {
 	return nil, fmt.Errorf("unimplemented")
 }
 

--- a/intf/intf.go
+++ b/intf/intf.go
@@ -24,7 +24,7 @@ import (
 	"net"
 )
 
-// Link represents information corresponding to a single interface on the
+// Interface represents information corresponding to a single interface on the
 // underlying system.
 type Interface struct {
 	// Index is an integer index used to refer to the interface.
@@ -35,8 +35,8 @@ type Interface struct {
 	MAC net.HardwareAddr
 }
 
-// ARPNeigh is a representation of an ARP entry on the underlying system.
-type ARPNeigh struct {
+// ARPEntry is a representation of an ARP entry on the underlying system.
+type ARPEntry struct {
 	// IP is the IP address of the neighbour.
 	IP net.IP
 	// Interface is the name of the interface on which the ARP entry was learnt.
@@ -62,7 +62,7 @@ type ARPUpdate struct {
 	// Type indicates whether the event was an add or delete.
 	Type ARPEvent
 	// Neigh is the neighbour that the change corresponds to
-	Neigh ARPNeigh
+	Neigh ARPEntry
 }
 
 // NetworkAccessor is an interface implemented by the underlying system access
@@ -95,27 +95,27 @@ func (u unimplementedAccessor) Interface(_ string) (*Interface, error) {
 }
 
 // Interfaces returns unimplemented when asked to list interfaces.
-func (n unimplementedAccessor) Interfaces() ([]*Interface, error) {
+func (u unimplementedAccessor) Interfaces() ([]*Interface, error) {
 	return nil, fmt.Errorf("unimplemented")
 }
 
 // InterfaceAddresses returns unimplemented when asked for list IP addresses.
-func (n unimplementedAccessor) InterfaceAddresses(_ string) ([]*net.IPNet, error) {
+func (u unimplementedAccessor) InterfaceAddresses(_ string) ([]*net.IPNet, error) {
 	return nil, fmt.Errorf("unimplemented")
 }
 
 // AddInterfaceIP returns unimplemented when asked to add an interface.
-func (n unimplementedAccessor) AddInterfaceIP(_ string, _ *net.IPNet) error {
+func (u unimplementedAccessor) AddInterfaceIP(_ string, _ *net.IPNet) error {
 	return fmt.Errorf("unimplemented")
 }
 
 // ARPList returns unimplemented when asked to list ARP entries.
-func (n unimplementedAccessor) ARPList() ([]*ARPNeigh, error) {
+func (u unimplementedAccessor) ARPList() ([]*ARPNeigh, error) {
 	return nil, fmt.Errorf("unimplemented")
 }
 
 // ARPSubscribe returns unimplemented when asked to subscribe to ARP changes.
-func (n unimplementedAccessor) ARPSubscribe(_ chan ARPUpdate, _ chan struct{}) error {
+func (u unimplementedAccessor) ARPSubscribe(_ chan ARPUpdate, _ chan struct{}) error {
 	return fmt.Errorf("unimplemented")
 }
 

--- a/intf/intf_test.go
+++ b/intf/intf_test.go
@@ -1,0 +1,137 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package intf
+
+import (
+	"fmt"
+	"net"
+	"testing"
+)
+
+type validInterfaceAccessor struct {
+	unimplementedAccessor
+}
+
+func (validInterfaceAccessor) Interface(name string) (*Interface, error) {
+	switch name {
+	case "eth0":
+		return &Interface{}, nil
+	case "eth42":
+		return &Interface{}, fmt.Errorf("error")
+	}
+	return nil, fmt.Errorf("does not exist")
+}
+
+func TestValidInterface(t *testing.T) {
+	oldAccessor := accessor
+	defer func() {
+		accessor = oldAccessor
+	}()
+	accessor = validInterfaceAccessor{}
+
+	tests := []struct {
+		name string
+		in   string
+		want bool
+	}{{
+		name: "exists",
+		in:   "eth0",
+		want: true,
+	}, {
+		name: "does not exist",
+		in:   "eth42",
+		want: false,
+	}}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got, want := ValidInterface(tt.in), tt.want; got != want {
+				t.Fatalf("InterfaceValid(%s), did not get expected interface valid response, got: %v, want: %v", tt.in, got, want)
+			}
+		})
+	}
+}
+
+type addIPAccessor struct {
+	unimplementedAccessor
+}
+
+func (addIPAccessor) InterfaceAddresses(name string) ([]*net.IPNet, error) {
+	switch name {
+	case "no-addresses":
+		return nil, nil
+	case "one-address", "add-fails":
+		return []*net.IPNet{
+			{IP: net.ParseIP("192.0.2.1"), Mask: net.CIDRMask(30, 32)},
+		}, nil
+	case "two-addresses":
+		return []*net.IPNet{
+			{IP: net.ParseIP("192.0.2.1"), Mask: net.CIDRMask(30, 32)},
+			{IP: net.ParseIP("192.0.2.5"), Mask: net.CIDRMask(30, 32)},
+		}, nil
+	default:
+		return nil, fmt.Errorf("unknown interface %s", name)
+	}
+}
+
+func (addIPAccessor) AddInterfaceIP(intf string, _ *net.IPNet) error {
+	switch intf {
+	case "no-addresses", "one-address":
+		return nil
+	case "add-fails":
+		return fmt.Errorf("add IP failed")
+	default:
+		return fmt.Errorf("unknown interface")
+	}
+}
+
+func TestAddIP(t *testing.T) {
+	oldAccessor := accessor
+	defer func() {
+		accessor = oldAccessor
+	}()
+	accessor = addIPAccessor{}
+
+	tests := []struct {
+		name        string
+		inInterface string
+		inAddress   *net.IPNet
+		wantErr     bool
+	}{{
+		name:        "add interface to interface with no addresses",
+		inInterface: "no-addresses",
+		inAddress:   &net.IPNet{IP: net.ParseIP("192.0.2.0"), Mask: net.CIDRMask(31, 32)},
+	}, {
+		name:        "add existing address",
+		inInterface: "one-address",
+		inAddress:   &net.IPNet{IP: net.ParseIP("192.0.2.0"), Mask: net.CIDRMask(30, 32)},
+	}, {
+		name:        "unknown interface",
+		inInterface: "does-not-exist",
+		wantErr:     true,
+	}, {
+		name:        "add IP fails",
+		inInterface: "add fails",
+		wantErr:     true,
+	}}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := accessor.AddInterfaceIP(tt.inInterface, tt.inAddress); (err != nil) != tt.wantErr {
+				t.Fatalf("AddInterface(%s, %s): did not get expected error, got: %v, wantErr? %v", tt.inInterface, tt.inAddress, err, tt.wantErr)
+			}
+		})
+	}
+}


### PR DESCRIPTION
```
﻿ * (A) intf/*
  - Add a library that can be used by other libraries within magna that
    abstracts access to underlying interfaces. This allows the rest of the
    system to be agnostic to the type of implementation that it is running
    on.
  - Add a base implementation for Linux where calls are made to the system
    using netlink. This implementation can be used within a container where
    ethX interfaces are presented to the container.
```

@marcushines - PTAL at the approach I'm taking here for making this a bit more testable and portable. 
I wanted to make sure that if we wanted to have an instance that writes to a grpcwire or something
similar then we didn't have any dependency on kernel calls (i.e., netlink), but also suport existing
containers that have ethXX interfaces to write to. It adds some complexity - but I think it also
makes this code more testable. Would appreciate your thoughts on whether it is comprehensible :-)x 
