### PR TITLE
Add MPLS header parsing functions.

### DIFF
--- a/flows/common/common.go
+++ b/flows/common/common.go
@@ -1,0 +1,56 @@
+// Package common providers common OTG flow helper functions.
+package common
+
+import (
+	"fmt"
+
+	"github.com/google/gopacket"
+	"github.com/open-traffic-generator/snappi/gosnappi/otg"
+	"github.com/openconfig/magna/lwotg"
+)
+
+// Ports returns the transmit and receive ports in terms of the
+// physical interfaces of the underlying system for a flow.
+func Ports(flow *otg.Flow, intfs []*lwotg.OTGIntf) (tx string, rx string, err error) {
+	if flow.GetTxRx() == nil || flow.GetTxRx().GetChoice() != otg.FlowTxRx_Choice_port {
+		return "", "", fmt.Errorf("unsupported type of Tx/Rx specification, %v", flow.GetTxRx())
+	}
+
+	txName := flow.GetTxRx().GetPort().GetTxName()
+	rxName := flow.GetTxRx().GetPort().GetRxName()
+
+	for _, i := range intfs {
+		if i.OTGPortName == txName {
+			tx = i.SystemName
+		}
+		if i.OTGPortName == rxName {
+			rx = i.SystemName
+		}
+	}
+
+	if tx == "" || rx == "" {
+		return "", "", fmt.Errorf("unknown interface, tx: %q, rx: %q", tx, rx)
+	}
+
+	return tx, rx, nil
+}
+
+// Rate returns the number of packets per second that should be sent
+// for the flow to meet the specified rate. The specified headers are
+// used where packet size calculations are required.
+//
+// It returns a default rate of 1000 packets per second per the OTG
+// specification if there is no rate specified.
+//
+// TODO(robjs): support specifications other than simple PPS.
+func Rate(flow *otg.Flow, hdrs []gopacket.SerializableLayer) (int64, error) {
+	if flowT := flow.GetRate().GetChoice(); flowT != otg.FlowRate_Choice_pps && flowT != otg.FlowRate_Choice_unspecified {
+		return 0, fmt.Errorf("unsupported flow rate specification, %v", flowT)
+	}
+
+	pps := flow.GetRate().GetPps()
+	if pps == 0 {
+		return 1000, nil
+	}
+	return pps, nil
+}

--- a/flows/common/common_test.go
+++ b/flows/common/common_test.go
@@ -1,0 +1,124 @@
+package common
+
+import (
+	"testing"
+
+	"github.com/google/gopacket"
+	"github.com/open-traffic-generator/snappi/gosnappi/otg"
+	"github.com/openconfig/magna/lwotg"
+	"google.golang.org/protobuf/proto"
+)
+
+func TestPorts(t *testing.T) {
+	devValue := otg.FlowTxRx_Choice_device
+	portValue := otg.FlowTxRx_Choice_port
+
+	tests := []struct {
+		desc           string
+		inFlow         *otg.Flow
+		inIntfs        []*lwotg.OTGIntf
+		wantTx, wantRx string
+		wantErr        bool
+	}{{
+		desc: "invalid flow type",
+		inFlow: &otg.Flow{
+			TxRx: &otg.FlowTxRx{
+				Choice: &devValue,
+			},
+		},
+		wantErr: true,
+	}, {
+		desc: "missing interfaces",
+		inFlow: &otg.Flow{
+			TxRx: &otg.FlowTxRx{
+				Choice: &portValue,
+				Port: &otg.FlowPort{
+					TxName: "port1",
+					RxName: proto.String("port2"),
+				},
+			},
+		},
+		wantErr: true,
+	}, {
+		desc: "valid specification",
+		inFlow: &otg.Flow{
+			TxRx: &otg.FlowTxRx{
+				Choice: &portValue,
+				Port: &otg.FlowPort{
+					TxName: "port1",
+					RxName: proto.String("port2"),
+				},
+			},
+		},
+		inIntfs: []*lwotg.OTGIntf{{
+			OTGPortName: "port1",
+			SystemName:  "eth0",
+		}, {
+			OTGPortName: "port2",
+			SystemName:  "eth1",
+		}},
+		wantTx: "eth0",
+		wantRx: "eth1",
+	}}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			gotTx, gotRx, err := Ports(tt.inFlow, tt.inIntfs)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("did not get expected error, got: %v, wantErr? %v", err, tt.wantErr)
+			}
+			if got, want := gotTx, tt.wantTx; got != want {
+				t.Errorf("did not get expected Tx port, got: %s, want: %s", got, want)
+			}
+			if got, want := gotRx, tt.wantRx; got != want {
+				t.Errorf("did not get expected Rx port, got: %s, want: %s", got, want)
+			}
+		})
+	}
+}
+
+func TestRate(t *testing.T) {
+	rateBPS := otg.FlowRate_Choice_bps
+	ratePPS := otg.FlowRate_Choice_pps
+
+	tests := []struct {
+		desc      string
+		inFlow    *otg.Flow
+		inHeaders []gopacket.SerializableLayer
+		wantPPS   int64
+		wantErr   bool
+	}{{
+		desc: "invalid specification",
+		inFlow: &otg.Flow{
+			Rate: &otg.FlowRate{
+				Choice: &rateBPS,
+			},
+		},
+		wantErr: true,
+	}, {
+		desc:    "default value",
+		inFlow:  &otg.Flow{},
+		wantPPS: 1000,
+	}, {
+		desc: "explicit value",
+		inFlow: &otg.Flow{
+			Rate: &otg.FlowRate{
+				Choice: &ratePPS,
+				Pps:    proto.Int64(1234),
+			},
+		},
+		wantPPS: 1234,
+	}}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			got, err := Rate(tt.inFlow, tt.inHeaders)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("did not get expected error, got: %v, wantErr? %v", err, tt.wantErr)
+			}
+			if want := tt.wantPPS; got != want {
+				t.Fatalf("did not get expected PPS, got: %d, want: %d", got, want)
+			}
+		})
+	}
+}

--- a/flows/mpls/mpls.go
+++ b/flows/mpls/mpls.go
@@ -7,16 +7,10 @@ package mpls
 import (
 	"fmt"
 	"net"
-	"time"
 
 	"github.com/google/gopacket"
 	"github.com/google/gopacket/layers"
 	"github.com/open-traffic-generator/snappi/gosnappi/otg"
-)
-
-var (
-	// timeout specifies how long to wait for a PCAP handle.
-	timeout = 30 * time.Second
 )
 
 const (

--- a/flows/mpls/mpls.go
+++ b/flows/mpls/mpls.go
@@ -1,3 +1,7 @@
+// Package mpls parses OTG flow descriptions that consist of
+// MPLS packets and returns functions that can generate and receive
+// packets for these flows. These can be used with the LWOTG
+// implementation.
 package mpls
 
 import (

--- a/flows/mpls/mpls.go
+++ b/flows/mpls/mpls.go
@@ -1,0 +1,104 @@
+package mpls
+
+import (
+	"fmt"
+	"net"
+	"time"
+
+	"github.com/google/gopacket"
+	"github.com/google/gopacket/layers"
+	"github.com/open-traffic-generator/snappi/gosnappi/otg"
+)
+
+var (
+	// timeout specifies how long to wait for a PCAP handle.
+	timeout = 30 * time.Second
+)
+
+const (
+	// defaultMPLSTTL is the TTL value used by default in the MPLS header.
+	defaultMPLSTTL uint8 = 64
+)
+
+// headers returns the gopacket layers for the specified flow.
+func headers(f *otg.Flow) ([]gopacket.SerializableLayer, error) {
+	var (
+		ethernet *otg.FlowHeader
+		mpls     []*otg.FlowHeader
+	)
+
+	// This package only handles MPLS packets, and there are restrictions on this. Thus we check
+	// that the packet that we've been asked for is something we can generate.
+	for _, layer := range f.Packet {
+		switch t := layer.GetChoice(); t {
+		case otg.FlowHeader_Choice_ethernet:
+			if ethernet != nil {
+				return nil, fmt.Errorf("multiple Ethernet layers not handled by MPLS plugin.")
+			}
+			ethernet = layer
+		case otg.FlowHeader_Choice_mpls:
+			mpls = append(mpls, layer)
+		default:
+			return nil, fmt.Errorf("MPLS does not handle layer %s", t)
+		}
+	}
+
+	if dstT := ethernet.GetEthernet().GetDst().GetChoice(); dstT != otg.PatternFlowEthernetDst_Choice_value {
+		return nil, fmt.Errorf("simple MPLS does not handle non-explicit destination MAC, got: %s", dstT)
+	}
+	if srcT := ethernet.GetEthernet().GetSrc().GetChoice(); srcT != otg.PatternFlowEthernetSrc_Choice_value {
+		return nil, fmt.Errorf("simple MPLS does not handle non-explicit src MAC, got: %v", srcT)
+	}
+
+	srcMAC, err := net.ParseMAC(ethernet.GetEthernet().GetSrc().GetValue())
+	if err != nil {
+		return nil, fmt.Errorf("cannot parse source MAC, %v", err)
+	}
+	dstMAC, err := net.ParseMAC(ethernet.GetEthernet().GetDst().GetValue())
+	if err != nil {
+		return nil, fmt.Errorf("cannot parse destination MAC, %v", err)
+	}
+
+	pktLayers := []gopacket.SerializableLayer{
+		&layers.Ethernet{
+			SrcMAC:       srcMAC,
+			DstMAC:       dstMAC,
+			EthernetType: layers.EthernetTypeMPLSUnicast,
+		},
+	}
+
+	// OTG says that the order of the layers must be the order on the wire.
+	for _, m := range mpls {
+		if valT := m.GetMpls().GetLabel().GetChoice(); valT != otg.PatternFlowMplsLabel_Choice_value {
+			return nil, fmt.Errorf("simple MPLS does not handle labels that do not have an explicit value, got: %v", valT)
+		}
+
+		if bosT := m.GetMpls().GetBottomOfStack().GetChoice(); bosT != otg.PatternFlowMplsBottomOfStack_Choice_value {
+			// TODO(robjs): It doesn't make sense here to
+			// have increment value - it can be 0 or 1.
+			// Possibly 'auto' should be suported. Bring
+			// this up with OTG designers.
+			return nil, fmt.Errorf("bottom of stack with non-explicit value requested, must be explicit, %v", bosT)
+		}
+
+		var ttl uint8
+		switch ttlT := m.GetMpls().GetTimeToLive().GetChoice(); ttlT {
+		case otg.PatternFlowMplsTimeToLive_Choice_value:
+			ttl = uint8(m.GetMpls().GetTimeToLive().GetValue())
+		case otg.PatternFlowMplsTimeToLive_Choice_unspecified:
+			ttl = defaultMPLSTTL
+		default:
+			return nil, fmt.Errorf("simple MPLS does not handle TTLs that are not explicitly set.")
+		}
+
+		ll := &layers.MPLS{
+			Label:       uint32(m.GetMpls().GetLabel().GetValue()),
+			TTL:         ttl,
+			StackBottom: m.GetMpls().GetBottomOfStack().GetValue() == 1,
+		}
+
+		pktLayers = append(pktLayers, ll)
+	}
+
+	return pktLayers, nil
+}

--- a/flows/mpls/mpls.go
+++ b/flows/mpls/mpls.go
@@ -31,7 +31,7 @@ func headers(f *otg.Flow) ([]gopacket.SerializableLayer, error) {
 		switch t := layer.GetChoice(); t {
 		case otg.FlowHeader_Choice_ethernet:
 			if ethernet != nil {
-				return nil, fmt.Errorf("multiple Ethernet layers not handled by MPLS plugin.")
+				return nil, fmt.Errorf("multiple Ethernet layers not handled by MPLS plugin")
 			}
 			ethernet = layer
 		case otg.FlowHeader_Choice_mpls:
@@ -86,7 +86,7 @@ func headers(f *otg.Flow) ([]gopacket.SerializableLayer, error) {
 		case otg.PatternFlowMplsTimeToLive_Choice_unspecified:
 			ttl = defaultMPLSTTL
 		default:
-			return nil, fmt.Errorf("simple MPLS does not handle TTLs that are not explicitly set.")
+			return nil, fmt.Errorf("simple MPLS does not handle TTLs that are not explicitly set")
 		}
 
 		ll := &layers.MPLS{

--- a/flows/mpls/mpls_test.go
+++ b/flows/mpls/mpls_test.go
@@ -1,0 +1,360 @@
+package mpls
+
+import (
+	"net"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	"github.com/google/gopacket"
+	"github.com/google/gopacket/layers"
+	"github.com/open-traffic-generator/snappi/gosnappi/otg"
+	"google.golang.org/protobuf/proto"
+)
+
+func TestHeaders(t *testing.T) {
+	v4Choice := otg.FlowHeader_Choice_ipv4
+	mplsChoice := otg.FlowHeader_Choice_mpls
+	ethernetChoice := otg.FlowHeader_Choice_ethernet
+
+	dstMACValue := otg.PatternFlowEthernetDst_Choice_value
+	dstMACValues := otg.PatternFlowEthernetDst_Choice_values
+
+	srcMACValue := otg.PatternFlowEthernetSrc_Choice_value
+	srcMACValues := otg.PatternFlowEthernetSrc_Choice_values
+
+	mplsTTLValue := otg.PatternFlowMplsTimeToLive_Choice_value
+	mplsTTLValues := otg.PatternFlowMplsTimeToLive_Choice_values
+	mplsBOSValue := otg.PatternFlowMplsBottomOfStack_Choice_value
+	mplsBOSValues := otg.PatternFlowMplsBottomOfStack_Choice_values
+	mplsLabelValue := otg.PatternFlowMplsLabel_Choice_value
+	mplsLabelValues := otg.PatternFlowMplsLabel_Choice_values
+
+	validMAC, err := net.ParseMAC("00:01:02:03:04:05")
+	if err != nil {
+		t.Fatalf("cannot parse MAC, %v", err)
+	}
+
+	tests := []struct {
+		desc       string
+		inFlow     *otg.Flow
+		wantLayers []gopacket.SerializableLayer
+		wantErr    bool
+	}{{
+		desc:    "no layers",
+		inFlow:  &otg.Flow{},
+		wantErr: true,
+	}, {
+		desc: "non-ethernet or mpls layer",
+		inFlow: &otg.Flow{
+			Packet: []*otg.FlowHeader{{
+				Choice: &v4Choice,
+			}},
+		},
+		wantErr: true,
+	}, {
+		desc: "multiple ethernet layers",
+		inFlow: &otg.Flow{
+			Packet: []*otg.FlowHeader{{
+				Choice: &ethernetChoice,
+			}, {
+				Choice: &mplsChoice,
+			}, {
+				Choice: &ethernetChoice,
+			}},
+		},
+		wantErr: true,
+	}, {
+		desc: "invalid destination MAC type",
+		inFlow: &otg.Flow{
+			Packet: []*otg.FlowHeader{{
+				Choice: &ethernetChoice,
+				Ethernet: &otg.FlowEthernet{
+					Dst: &otg.PatternFlowEthernetDst{
+						Choice: &dstMACValues,
+					},
+				},
+			}},
+		},
+		wantErr: true,
+	}, {
+		desc: "invalid source MAC type",
+		inFlow: &otg.Flow{
+			Packet: []*otg.FlowHeader{{
+				Choice: &ethernetChoice,
+				Ethernet: &otg.FlowEthernet{
+					Src: &otg.PatternFlowEthernetSrc{
+						Choice: &srcMACValues,
+					},
+				},
+			}},
+		},
+		wantErr: true,
+	}, {
+		desc: "valid MACs",
+		inFlow: &otg.Flow{
+			Packet: []*otg.FlowHeader{{
+				Choice: &ethernetChoice,
+				Ethernet: &otg.FlowEthernet{
+					Dst: &otg.PatternFlowEthernetDst{
+						Choice: &dstMACValue,
+						Value:  proto.String("00:01:02:03:04:05"),
+					},
+					Src: &otg.PatternFlowEthernetSrc{
+						Choice: &srcMACValue,
+						Value:  proto.String("00:01:02:03:04:05"),
+					},
+				},
+			}},
+		},
+		wantLayers: []gopacket.SerializableLayer{
+			&layers.Ethernet{
+				SrcMAC:       validMAC,
+				DstMAC:       validMAC,
+				EthernetType: layers.EthernetTypeMPLSUnicast,
+			},
+		},
+	}, {
+		desc: "invalid destination MAC",
+		inFlow: &otg.Flow{
+			Packet: []*otg.FlowHeader{{
+				Choice: &ethernetChoice,
+				Ethernet: &otg.FlowEthernet{
+					Dst: &otg.PatternFlowEthernetDst{
+						Choice: &dstMACValue,
+						Value:  proto.String("not-a-mac"),
+					},
+					Src: &otg.PatternFlowEthernetSrc{
+						Choice: &srcMACValue,
+						Value:  proto.String("00:01:02:03:04:05"),
+					},
+				},
+			}},
+		},
+		wantErr: true,
+	}, {
+		desc: "invalid source MAC",
+		inFlow: &otg.Flow{
+			Packet: []*otg.FlowHeader{{
+				Choice: &ethernetChoice,
+				Ethernet: &otg.FlowEthernet{
+					Dst: &otg.PatternFlowEthernetDst{
+						Choice: &dstMACValue,
+						Value:  proto.String("00:01:02:03:04:05"),
+					},
+					Src: &otg.PatternFlowEthernetSrc{
+						Choice: &srcMACValue,
+						Value:  proto.String("not-a-mac"),
+					},
+				},
+			}},
+		},
+		wantErr: true,
+	}, {
+		desc: "single MPLS header",
+		inFlow: &otg.Flow{
+			Packet: []*otg.FlowHeader{{
+				Choice: &ethernetChoice,
+				Ethernet: &otg.FlowEthernet{
+					Dst: &otg.PatternFlowEthernetDst{
+						Choice: &dstMACValue,
+						Value:  proto.String("00:01:02:03:04:05"),
+					},
+					Src: &otg.PatternFlowEthernetSrc{
+						Choice: &srcMACValue,
+						Value:  proto.String("00:01:02:03:04:05"),
+					},
+				},
+			}, {
+				Choice: &mplsChoice,
+				Mpls: &otg.FlowMpls{
+					Label: &otg.PatternFlowMplsLabel{
+						Choice: &mplsLabelValue,
+						Value:  proto.Int32(42),
+					},
+					TimeToLive: &otg.PatternFlowMplsTimeToLive{
+						Choice: &mplsTTLValue,
+						Value:  proto.Int32(2),
+					},
+					BottomOfStack: &otg.PatternFlowMplsBottomOfStack{
+						Choice: &mplsBOSValue,
+						Value:  proto.Int32(1),
+					},
+				},
+			}},
+		},
+		wantLayers: []gopacket.SerializableLayer{
+			&layers.Ethernet{
+				SrcMAC:       validMAC,
+				DstMAC:       validMAC,
+				EthernetType: layers.EthernetTypeMPLSUnicast,
+			},
+			&layers.MPLS{
+				Label:       42,
+				StackBottom: true,
+				TTL:         2,
+			},
+		},
+	}, {
+		desc: "invalid MPLS label type",
+		inFlow: &otg.Flow{
+			Packet: []*otg.FlowHeader{{
+				Choice: &ethernetChoice,
+				Ethernet: &otg.FlowEthernet{
+					Dst: &otg.PatternFlowEthernetDst{
+						Choice: &dstMACValue,
+						Value:  proto.String("00:01:02:03:04:05"),
+					},
+					Src: &otg.PatternFlowEthernetSrc{
+						Choice: &srcMACValue,
+						Value:  proto.String("00:01:02:03:04:05"),
+					},
+				},
+			}, {
+				Choice: &mplsChoice,
+				Mpls: &otg.FlowMpls{
+					Label: &otg.PatternFlowMplsLabel{
+						Choice: &mplsLabelValues,
+					},
+				},
+			}},
+		},
+		wantErr: true,
+	}, {
+		desc: "invalid MPLS TTL type",
+		inFlow: &otg.Flow{
+			Packet: []*otg.FlowHeader{{
+				Choice: &ethernetChoice,
+				Ethernet: &otg.FlowEthernet{
+					Dst: &otg.PatternFlowEthernetDst{
+						Choice: &dstMACValue,
+						Value:  proto.String("00:01:02:03:04:05"),
+					},
+					Src: &otg.PatternFlowEthernetSrc{
+						Choice: &srcMACValue,
+						Value:  proto.String("00:01:02:03:04:05"),
+					},
+				},
+			}, {
+				Choice: &mplsChoice,
+				Mpls: &otg.FlowMpls{
+					Label: &otg.PatternFlowMplsLabel{
+						Choice: &mplsLabelValue,
+						Value:  proto.Int32(42),
+					},
+					TimeToLive: &otg.PatternFlowMplsTimeToLive{
+						Choice: &mplsTTLValues,
+					},
+				},
+			}},
+		},
+		wantErr: true,
+	}, {
+		desc: "invalid MPLS BOS type",
+		inFlow: &otg.Flow{
+			Packet: []*otg.FlowHeader{{
+				Choice: &ethernetChoice,
+				Ethernet: &otg.FlowEthernet{
+					Dst: &otg.PatternFlowEthernetDst{
+						Choice: &dstMACValue,
+						Value:  proto.String("00:01:02:03:04:05"),
+					},
+					Src: &otg.PatternFlowEthernetSrc{
+						Choice: &srcMACValue,
+						Value:  proto.String("00:01:02:03:04:05"),
+					},
+				},
+			}, {
+				Choice: &mplsChoice,
+				Mpls: &otg.FlowMpls{
+					Label: &otg.PatternFlowMplsLabel{
+						Choice: &mplsLabelValue,
+						Value:  proto.Int32(42),
+					},
+					TimeToLive: &otg.PatternFlowMplsTimeToLive{
+						Choice: &mplsTTLValue,
+						Value:  proto.Int32(2),
+					},
+					BottomOfStack: &otg.PatternFlowMplsBottomOfStack{
+						Choice: &mplsBOSValues,
+					},
+				},
+			}},
+		},
+		wantErr: true,
+	}, {
+		desc: "multiple MPLS headers",
+		inFlow: &otg.Flow{
+			Packet: []*otg.FlowHeader{{
+				Choice: &ethernetChoice,
+				Ethernet: &otg.FlowEthernet{
+					Dst: &otg.PatternFlowEthernetDst{
+						Choice: &dstMACValue,
+						Value:  proto.String("00:01:02:03:04:05"),
+					},
+					Src: &otg.PatternFlowEthernetSrc{
+						Choice: &srcMACValue,
+						Value:  proto.String("00:01:02:03:04:05"),
+					},
+				},
+			}, {
+				Choice: &mplsChoice,
+				Mpls: &otg.FlowMpls{
+					Label: &otg.PatternFlowMplsLabel{
+						Choice: &mplsLabelValue,
+						Value:  proto.Int32(42),
+					},
+					TimeToLive: &otg.PatternFlowMplsTimeToLive{
+						Choice: &mplsTTLValue,
+						Value:  proto.Int32(2),
+					},
+					BottomOfStack: &otg.PatternFlowMplsBottomOfStack{
+						Choice: &mplsBOSValue,
+						Value:  proto.Int32(0),
+					},
+				},
+			}, {
+				Choice: &mplsChoice,
+				Mpls: &otg.FlowMpls{
+					Label: &otg.PatternFlowMplsLabel{
+						Choice: &mplsLabelValue,
+						Value:  proto.Int32(84),
+					},
+					BottomOfStack: &otg.PatternFlowMplsBottomOfStack{
+						Choice: &mplsBOSValue,
+						Value:  proto.Int32(1),
+					},
+				},
+			}},
+		},
+		wantLayers: []gopacket.SerializableLayer{
+			&layers.Ethernet{
+				SrcMAC:       validMAC,
+				DstMAC:       validMAC,
+				EthernetType: layers.EthernetTypeMPLSUnicast,
+			},
+			&layers.MPLS{
+				Label:       42,
+				StackBottom: false,
+				TTL:         2,
+			},
+			&layers.MPLS{
+				Label:       84,
+				StackBottom: true,
+				TTL:         defaultMPLSTTL,
+			},
+		},
+	}}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			got, err := headers(tt.inFlow)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("did not get expected error, got: %v, wantErr? %v", err, tt.wantErr)
+			}
+			if diff := cmp.Diff(got, tt.wantLayers, cmpopts.EquateEmpty()); diff != "" {
+				t.Fatalf("did not get expected layers, diff(-got,+want):\n%s", diff)
+			}
+		})
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -17,6 +17,7 @@ require (
 require (
 	github.com/golang/glog v1.0.0 // indirect
 	github.com/golang/protobuf v1.5.2 // indirect
+	github.com/google/gopacket v1.1.19 // indirect
 	github.com/kylelemons/godebug v1.1.0 // indirect
 	github.com/openconfig/goyang v1.1.0 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -57,6 +57,8 @@ github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
 github.com/google/go-cmp v0.5.6/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.7 h1:81/ik6ipDQS2aGcBfIN5dHDB36BwrStyeAQquSYCV4o=
 github.com/google/go-cmp v0.5.7/go.mod h1:n+brtR0CgQNWTVd5ZUFpTBC8YFBDLK/h/bpaJ8/DtOE=
+github.com/google/gopacket v1.1.19 h1:ves8RnFZPGiFnTS0uPQStjwru6uO6h+nlr9j6fL7kF8=
+github.com/google/gopacket v1.1.19/go.mod h1:iJ8V8n6KS+z2U1A8pUwu8bW5SyEMkXJB8Yo/Vo+TKTo=
 github.com/google/protobuf v3.11.4+incompatible/go.mod h1:lUQ9D1ePzbH2PrIS7ob/bjm9HXyH5WHB0Akwh7URreM=
 github.com/google/uuid v1.1.2/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/gorilla/mux v1.8.0/go.mod h1:DVbg23sWSpFRCP0SfiEN6jmj59UnW/n46BH5rLB71So=
@@ -110,6 +112,7 @@ golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL
 golang.org/x/lint v0.0.0-20181026193005-c67002cb31c3/go.mod h1:UVdnD1Gm6xHRNCYTkRU2/jEulfH38KcIWyp/GAMgvoE=
 golang.org/x/lint v0.0.0-20190227174305-5b3e6a55c961/go.mod h1:wehouNa3lNwaWXcvxsM5YxQ5yQlVC4a0KAMCusXpPoU=
 golang.org/x/lint v0.0.0-20190313153728-d0100b6bd8b3/go.mod h1:6SW0HCj/g11FgYtHlgUYUwCkIfeOF89ocIRzGO/8vkc=
+golang.org/x/lint v0.0.0-20200302205851-738671d3881b/go.mod h1:3xt1FjdF8hUf6vQPIChWIBhFzV8gjjsPE/fR3IyQdNY=
 golang.org/x/lint v0.0.0-20210508222113-6edffad5e616/go.mod h1:3xt1FjdF8hUf6vQPIChWIBhFzV8gjjsPE/fR3IyQdNY=
 golang.org/x/mod v0.1.1-0.20191105210325-c90efee705ee/go.mod h1:QqPTAvyqsEbceGzBzNggFXnrqF1CaUcvgkdR5Ot7KZg=
 golang.org/x/mod v0.4.2/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=

--- a/lwotg/flows.go
+++ b/lwotg/flows.go
@@ -39,10 +39,10 @@ func NewFlowController() *FlowController {
 //
 // The arguments to a FlowGeneratorFn are as follows:
 //   - otg.Flow - the flow that is to be generated as described by the OTG schema.
-//   - []*otgIntf - information as to the set of interfaces that are currently within the OTG
+//   - []*OTGIntf - information as to the set of interfaces that are currently within the OTG
 //     configuration. This information can be used to map the flow creation functionality to
 //     the underlying interface.
-type FlowGeneratorFn func(*otg.Flow, []*otgIntf) (TXRXFn, bool, error)
+type FlowGeneratorFn func(*otg.Flow, []*OTGIntf) (TXRXFn, bool, error)
 
 // AddFlowHandlers adds the set of flow generator functions specified to the flow handlers that
 // are considered as candidates by the server.

--- a/lwotg/flows_test.go
+++ b/lwotg/flows_test.go
@@ -33,7 +33,7 @@ func TestHandleFlows(t *testing.T) {
 			Name: "handled",
 		}},
 		inFns: []FlowGeneratorFn{
-			func(_ *otg.Flow, _ []*otgIntf) (TXRXFn, bool, error) {
+			func(_ *otg.Flow, _ []*OTGIntf) (TXRXFn, bool, error) {
 				return func(tx, rx *FlowController) {}, true, nil
 			},
 		},
@@ -46,7 +46,7 @@ func TestHandleFlows(t *testing.T) {
 			Name: "handled-2",
 		}},
 		inFns: []FlowGeneratorFn{
-			func(_ *otg.Flow, _ []*otgIntf) (TXRXFn, bool, error) {
+			func(_ *otg.Flow, _ []*OTGIntf) (TXRXFn, bool, error) {
 				return func(tx, rx *FlowController) {}, true, nil
 			},
 		},
@@ -57,7 +57,7 @@ func TestHandleFlows(t *testing.T) {
 			Name: "error",
 		}},
 		inFns: []FlowGeneratorFn{
-			func(_ *otg.Flow, _ []*otgIntf) (TXRXFn, bool, error) {
+			func(_ *otg.Flow, _ []*OTGIntf) (TXRXFn, bool, error) {
 				return nil, true, fmt.Errorf("unhandled")
 			},
 		},

--- a/lwotg/intf.go
+++ b/lwotg/intf.go
@@ -8,8 +8,8 @@ import (
 	"google.golang.org/grpc/status"
 )
 
-// otgIntf describes an interface in the OTG configuration.
-type otgIntf struct {
+// OTGIntf describes an interface in the OTG configuration.
+type OTGIntf struct {
 	// OTGEthernetName specifies the name of the interface in the OTG configuration when referred to
 	// as an Ethernet port.
 	OTGEthernetName string
@@ -40,8 +40,8 @@ type ipAddress struct {
 // underlying system. OTG devices have a set of ethernet ports that are associated with them, which
 // use the names that are specified in the ports map.
 //
-// It returns a slice of otgIntf structs that describe the system interfaces.
-func portsToSystem(ports []*otg.Port, devices []*otg.Device) ([]*otgIntf, error) {
+// It returns a slice of OTGIntf structs that describe the system interfaces.
+func portsToSystem(ports []*otg.Port, devices []*otg.Device) ([]*OTGIntf, error) {
 	physIntf := map[string]string{}
 	for _, p := range ports {
 		if p.Location == nil {
@@ -50,7 +50,7 @@ func portsToSystem(ports []*otg.Port, devices []*otg.Device) ([]*otgIntf, error)
 		physIntf[p.Name] = *p.Location
 	}
 
-	intfs := []*otgIntf{}
+	intfs := []*OTGIntf{}
 	for _, d := range devices {
 		for _, e := range d.Ethernets {
 			if e.GetPortName() == "" {
@@ -61,7 +61,7 @@ func portsToSystem(ports []*otg.Port, devices []*otg.Device) ([]*otgIntf, error)
 				return nil, status.Errorf(codes.InvalidArgument, "invalid port name for Ethernet %s, does not map to a physical interface", *e.PortName)
 			}
 
-			i := &otgIntf{
+			i := &OTGIntf{
 				OTGEthernetName: e.Name,
 				OTGPortName:     *e.PortName,
 				SystemName:      sysInt,

--- a/lwotg/intf_test.go
+++ b/lwotg/intf_test.go
@@ -15,7 +15,7 @@ func TestPortsToSystem(t *testing.T) {
 		desc      string
 		inPorts   []*otg.Port
 		inDevices []*otg.Device
-		wantIntf  []*otgIntf
+		wantIntf  []*OTGIntf
 		wantErr   bool
 	}{{
 		desc: "interface with no location",
@@ -58,7 +58,7 @@ func TestPortsToSystem(t *testing.T) {
 				PortName: proto.String("port0"),
 			}},
 		}},
-		wantIntf: []*otgIntf{{
+		wantIntf: []*OTGIntf{{
 			OTGEthernetName: "port0ETH",
 			OTGPortName:     "port0",
 			SystemName:      "eth0",
@@ -80,7 +80,7 @@ func TestPortsToSystem(t *testing.T) {
 				}},
 			}},
 		}},
-		wantIntf: []*otgIntf{{
+		wantIntf: []*OTGIntf{{
 			OTGEthernetName: "port0ETH",
 			OTGPortName:     "port0",
 			SystemName:      "eth0",
@@ -122,7 +122,7 @@ func TestPortsToSystem(t *testing.T) {
 				}},
 			}},
 		}},
-		wantIntf: []*otgIntf{{
+		wantIntf: []*OTGIntf{{
 			OTGEthernetName: "port0ETH",
 			OTGPortName:     "port0",
 			SystemName:      "eth0",

--- a/lwotg/lwotg.go
+++ b/lwotg/lwotg.go
@@ -72,7 +72,7 @@ type Server struct {
 	// intMu protects the intfCache.
 	intfMu sync.Mutex
 	// intfCache is a cache of the current set of interfaces for the OTG configuration.
-	intfCache []*otgIntf
+	intfCache []*OTGIntf
 
 	// tgMu protects the trafficGenerators and generatorChs slices.
 	tgMu sync.Mutex
@@ -176,11 +176,11 @@ func (s *Server) SetTransmitState(ctx context.Context, req *otg.SetTransmitState
 }
 
 // interfaces returns a copy of the cached set of interfaces in the server.
-func (s *Server) interfaces() []*otgIntf {
+func (s *Server) interfaces() []*OTGIntf {
 	s.intfMu.Lock()
 	defer s.intfMu.Unlock()
 
-	return append([]*otgIntf{}, s.intfCache...)
+	return append([]*OTGIntf{}, s.intfCache...)
 }
 
 // baseInterfaceHandler is a built-in handler for interface configuration which is used as a configHandler.

--- a/lwotg/lwotg_test.go
+++ b/lwotg/lwotg_test.go
@@ -139,7 +139,7 @@ func TestSetConfig(t *testing.T) {
 	}, {
 		desc: "error in flow handler",
 		inFlowHandlers: []FlowGeneratorFn{
-			func(*otg.Flow, []*otgIntf) (TXRXFn, bool, error) {
+			func(*otg.Flow, []*OTGIntf) (TXRXFn, bool, error) {
 				return nil, false, fmt.Errorf("cannot parse")
 			},
 		},
@@ -154,7 +154,7 @@ func TestSetConfig(t *testing.T) {
 	}, {
 		desc: "generated flow",
 		inFlowHandlers: []FlowGeneratorFn{
-			func(*otg.Flow, []*otgIntf) (TXRXFn, bool, error) {
+			func(*otg.Flow, []*OTGIntf) (TXRXFn, bool, error) {
 				return func(_, _ *FlowController) {}, true, nil
 			},
 		},


### PR DESCRIPTION
```
commit 0fec17af20ffeaf6208fccbf6bb3c45526cd252a
Author: Rob Shakir <robjs@google.com>
Date:   Sat Aug 27 14:47:49 2022 -0700

    Add function for converting otg.Flow -> gopacket MPLS headers.
    
     * (A) flow/mpls/*
       - Add package that generates gopacket packet definitions from OTG
         flows for MPLS to allow for MPLS packet generation.
```
