### PR TITLE
Add integration test for e2e magna testing. [3/3] 

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -37,17 +37,31 @@ jobs:
       run: go build -v ./...
 
     - name: Test
-      run: sudo go test -v -coverprofile=profile.cov ./...
+      run: |
+        go list ./... | egrep -v "magna/(e2e|cmd/(magna|mirror)|otgyang)" | while read l; do 
+          dir=`echo $l | sed 's/^github.com\/openconfig\/magna//g'`; 
+          fn=`echo $dir | sed 's/\//_/g'`; 
+          sudo go test -v .$dir -covermode=count -coverprofile=$fn.cover.profile; 
+        done; 
+        echo "mode: count" > combined.coverprofile; 
+        for i in `ls *.cover.profile`; do 
+          tail -n +2 $i >> combined.coverprofile; 
+        done; 
+        rm *.cover.profile
 
     - name: Race Test
       run: |
-          sudo go test -race ./...
+        go list ./... | egrep -v "magna/(e2e|cmd/(magna|mirror)|otgyang)" | while read l; do 
+          dir=`echo $l | sed 's/^github.com\/openconfig\/magna//g'`; 
+          fn=`echo $dir | sed 's/\//_/g'`; 
+          sudo go test -v -race .$dir 
+        done; 
 
     - name: Coveralls
       if: ${{ matrix.go == '1.x' }}
       uses: shogo82148/actions-goveralls@v1
       with:
-        path-to-profile: profile.cov
+        path-to-profile: combined.coverprofile
 
   static_analysis:
     name: Static Analysis

--- a/cmd/mirror/main.go
+++ b/cmd/mirror/main.go
@@ -28,11 +28,12 @@ func main() {
 	ms := mirrorsrv.New()
 	mpb.RegisterMirrorServer(srv, ms)
 
-	lis, err := net.Listen("tcp", fmt.Sprintf("localhost:%d", *port))
+	lis, err := net.Listen("tcp", fmt.Sprintf("0.0.0.0:%d", *port))
 	if err != nil {
 		klog.Exitf("cannot start listening, got err: %v", err)
 	}
 
+	klog.Infof("mirror server listening on %s", lis.Addr().String())
 	defer srv.Stop()
 
 	var wg sync.WaitGroup

--- a/e2e/simple_ondatra_test.go
+++ b/e2e/simple_ondatra_test.go
@@ -165,6 +165,7 @@ func TestMPLS(t *testing.T) {
 	client, stop := mirrorClient(t, maddr)
 	defer stop()
 	startMirror(t, client)
+	time.Sleep(1 * time.Second)
 	defer func() { stopMirror(t, client) }()
 
 	otgCfg := pushBaseConfigs(t, ondatra.ATE(t, "ate"))
@@ -205,6 +206,8 @@ func TestMPLS(t *testing.T) {
 	t.Logf("Stopping MPLS traffic...")
 	otg.StopTraffic(t)
 
+	// Avoid a race with telemetry updates.
+	time.Sleep(1 * time.Second)
 	metrics := gnmi.Get(t, otg, gnmi.OTG().Flow("MPLS_FLOW").State())
 	got, want := metrics.GetCounters().GetInPkts(), metrics.GetCounters().GetOutPkts()
 	lossPackets := want - got

--- a/e2e/simple_ondatra_test.go
+++ b/e2e/simple_ondatra_test.go
@@ -1,0 +1,214 @@
+package simple_ondatra_test
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"net"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/open-traffic-generator/snappi/gosnappi"
+	"github.com/openconfig/featureprofiles/topologies/binding"
+	"github.com/openconfig/ondatra"
+	"github.com/openconfig/ondatra/gnmi"
+	"github.com/openconfig/ondatra/knebind/solver"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+
+	tpb "github.com/openconfig/kne/proto/topo"
+	mpb "github.com/openconfig/magna/proto/mirror"
+)
+
+const (
+	// destinationLabel is the outer label that is used for the generated packets in MPLS flows.
+	destinationLabel = 100
+	// innerLabel is the inner label used for the generated packets in MPLS flows.
+	innerLabel = 5000
+)
+
+var (
+	// sleepTime allows a user to specify that the test should sleep after setting
+	// up all elements (configuration, gRIBI forwarding entries, traffic flows etc.).
+	sleepTime = flag.Duration("sleep", 10*time.Second, "duration for which the test should sleep after setup")
+)
+
+// intf is a simple description of an interface.
+type intf struct {
+	// Name is the name of the interface.
+	Name string
+	// MAC is the MAC address for the interface.
+	MAC string
+}
+
+var (
+	// ateSrc describes the configuration parameters for the ATE port sourcing
+	// a flow.
+	ateSrc = &intf{
+		Name: "port1",
+		MAC:  "02:00:01:01:01:01",
+	}
+
+	ateDst = &intf{
+		Name: "port2",
+		MAC:  "02:00:02:01:01:01",
+	}
+)
+
+func TestMain(m *testing.M) {
+	ondatra.RunTests(m, binding.New)
+}
+
+// configureATE interfaces configrues the source and destination ports on ATE according to the specifications
+// above. It returns the OTG configuration object.
+func configureATEInterfaces(t *testing.T, ate *ondatra.ATEDevice, srcATE, dstATE *intf) (gosnappi.Config, error) {
+	otg := ate.OTG()
+	topology := otg.NewConfig(t)
+	for _, p := range []*intf{ateSrc, ateDst} {
+		topology.Ports().Add().SetName(p.Name)
+		dev := topology.Devices().Add().SetName(p.Name)
+		eth := dev.Ethernets().Add().SetName(fmt.Sprintf("%s_ETH", p.Name))
+		eth.SetPortName(dev.Name()).SetMac(p.MAC)
+	}
+
+	c, err := topology.ToJson()
+	if err != nil {
+		return topology, err
+	}
+	t.Logf("configuration for OTG is %s", c)
+
+	otg.PushConfig(t, topology)
+	return topology, nil
+}
+
+// pushBaseConfigs pushes the base configuration to the ATE and DUT devices in
+// the test topology.
+func pushBaseConfigs(t *testing.T, ate *ondatra.ATEDevice) gosnappi.Config {
+	otgCfg, err := configureATEInterfaces(t, ate, ateSrc, ateDst)
+	if err != nil {
+		t.Fatalf("cannot configure ATE interfaces via OTG, %v", err)
+	}
+
+	return otgCfg
+}
+
+func mirrorAddr(t *testing.T) string {
+	mirror := ondatra.DUT(t, "mirror")
+	data := mirror.CustomData(solver.KNEServiceMapKey).(map[string]*tpb.Service)
+	m := data["mirror-controller"]
+	if m == nil {
+		t.Fatalf("cannot find mirror data, got: %v", data)
+	}
+	return net.JoinHostPort(m.GetOutsideIp(), strconv.Itoa(int(m.GetOutside())))
+}
+
+func mirrorClient(t *testing.T, addr string) (mpb.MirrorClient, func() error) {
+	conn, err := grpc.Dial(addr,
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+		grpc.WithBlock(),
+	)
+	if err != nil {
+		t.Fatalf("cannot dial mirror, got err: %v", err)
+	}
+
+	return mpb.NewMirrorClient(conn), conn.Close
+}
+
+func startMirror(t *testing.T, client mpb.MirrorClient) {
+	t.Helper()
+	mirror := ondatra.DUT(t, "mirror")
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	startReq := &mpb.StartRequest{
+		From: mirror.Port(t, "port1").Name(),
+		To:   mirror.Port(t, "port2").Name(),
+	}
+	if _, err := client.Start(ctx, startReq); err != nil {
+		t.Fatalf("cannot start mirror client, got err: %v", err)
+	}
+}
+
+func stopMirror(t *testing.T, client mpb.MirrorClient) {
+	t.Helper()
+	mirror := ondatra.DUT(t, "mirror")
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	stopReq := &mpb.StopRequest{
+		From: mirror.Port(t, "port1").Name(),
+		To:   mirror.Port(t, "port2").Name(),
+	}
+	if _, err := client.Stop(ctx, stopReq); err != nil {
+		t.Fatalf("cannot stop mirror client, got err: %v", err)
+	}
+}
+
+func TestMirror(t *testing.T) {
+	addr := mirrorAddr(t)
+	client, stop := mirrorClient(t, addr)
+	defer stop()
+	startMirror(t, client)
+	time.Sleep(1 * time.Second)
+	stopMirror(t, client)
+}
+
+// TestMPLS is a simple test that creates an MPLS flow between two ATE ports and
+// checks that there is no packet loss. It validates magna's end-to-end MPLS
+// flow accounting.
+func TestMPLS(t *testing.T) {
+	// Start a mirroring session to copy packets.
+	maddr := mirrorAddr(t)
+	client, stop := mirrorClient(t, maddr)
+	defer stop()
+	startMirror(t, client)
+	defer func() { stopMirror(t, client) }()
+
+	otgCfg := pushBaseConfigs(t, ondatra.ATE(t, "ate"))
+
+	otg := ondatra.ATE(t, "ate").OTG()
+	otgCfg.Flows().Clear().Items()
+	mplsFlow := otgCfg.Flows().Add().SetName("MPLS_FLOW")
+	mplsFlow.Metrics().SetEnable(true)
+	mplsFlow.TxRx().Port().SetTxName(ateSrc.Name).SetRxName(ateDst.Name)
+
+	mplsFlow.Rate().SetChoice("pps").SetPps(1)
+
+	// Set up ethernet layer.
+	eth := mplsFlow.Packet().Add().Ethernet()
+	eth.Src().SetChoice("value").SetValue(ateSrc.MAC)
+	eth.Dst().SetChoice("value").SetValue(ateDst.MAC)
+
+	// Set up MPLS layer with destination label.
+	mpls := mplsFlow.Packet().Add().Mpls()
+	mpls.Label().SetChoice("value").SetValue(destinationLabel)
+	mpls.BottomOfStack().SetChoice("value").SetValue(0)
+
+	mplsInner := mplsFlow.Packet().Add().Mpls()
+	mplsInner.Label().SetChoice("value").SetValue(innerLabel)
+	mplsInner.BottomOfStack().SetChoice("value").SetValue(1)
+
+	ip4 := mplsFlow.Packet().Add().Ipv4()
+	ip4.Src().SetChoice("value").SetValue("100.64.1.1")
+	ip4.Dst().SetChoice("value").SetValue("100.64.1.2")
+	ip4.Version().SetChoice("value").SetValue(4)
+
+	otg.PushConfig(t, otgCfg)
+
+	t.Logf("Starting MPLS traffic...")
+	otg.StartTraffic(t)
+	t.Logf("Sleeping for %s...", *sleepTime)
+	time.Sleep(*sleepTime)
+	t.Logf("Stopping MPLS traffic...")
+	otg.StopTraffic(t)
+
+	metrics := gnmi.Get(t, otg, gnmi.OTG().Flow("MPLS_FLOW").State())
+	got, want := metrics.GetCounters().GetInPkts(), metrics.GetCounters().GetOutPkts()
+	lossPackets := want - got
+	if lossPackets != 0 {
+		t.Fatalf("did not get expected number of packets, got: %d, want: %d", got, want)
+	}
+}

--- a/e2e/simple_ondatra_test.go
+++ b/e2e/simple_ondatra_test.go
@@ -226,8 +226,7 @@ func TestMPLS(t *testing.T) {
 	time.Sleep(1 * time.Second)
 	metrics := gnmi.Get(t, otg, gnmi.OTG().Flow("MPLS_FLOW").State())
 	got, want := metrics.GetCounters().GetInPkts(), metrics.GetCounters().GetOutPkts()
-	lossPackets := want - got
-	if lossPackets != 0 {
+	if lossPackets := want - got; lossPackets != 0 {
 		t.Fatalf("did not get expected number of packets, got: %d, want: %d", got, want)
 	}
 }

--- a/go.mod
+++ b/go.mod
@@ -128,4 +128,4 @@ require (
 	sigs.k8s.io/yaml v1.3.0 // indirect
 )
 
-replace github.com/openconfig/ondatra => /usr/local/google/home/robjs/go/src/github.com/openconfig/ondatra
+replace github.com/openconfig/ondatra => github.com/robshakir/ondatra

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/open-traffic-generator/snappi/gosnappi v0.11.15
 	github.com/openconfig/gnmi v0.9.1
 	github.com/openconfig/goyang v1.4.0
-	github.com/openconfig/ondatra v0.1.23
+	github.com/openconfig/ondatra v0.1.24-0.20230707220529-4774ac3d2272
 	github.com/openconfig/ygot v0.28.3
 	github.com/vishvananda/netlink v1.1.1-0.20210330154013-f5de75959ad5
 	google.golang.org/grpc v1.56.0
@@ -127,5 +127,3 @@ require (
 	sigs.k8s.io/structured-merge-diff/v4 v4.2.3 // indirect
 	sigs.k8s.io/yaml v1.3.0 // indirect
 )
-
-replace github.com/openconfig/ondatra => github.com/robshakir/ondatra

--- a/go.sum
+++ b/go.sum
@@ -873,6 +873,8 @@ github.com/openconfig/lemming/operator v0.2.0 h1:dovZnR6lQkOHXcODli1NDOr/GVYrBY0
 github.com/openconfig/lemming/operator v0.2.0/go.mod h1:LKgEXSR5VK2CAeh2uKijKAXFj42uQuwakrCHVPF0iII=
 github.com/openconfig/ondatra v0.1.23 h1:1yU7d9gOUJqOg+VEM5092J4ZS952/hTLoeQTX+aAhD0=
 github.com/openconfig/ondatra v0.1.23/go.mod h1:k6UKXpEg+BaDjYYXsAtZuKgP/hVO8f9J0FNViOBUkwk=
+github.com/openconfig/ondatra v0.1.24-0.20230707220529-4774ac3d2272 h1:b4s6Mx/MaiFgC248T9ytSckcH5JlAV15Swtj30zczkw=
+github.com/openconfig/ondatra v0.1.24-0.20230707220529-4774ac3d2272/go.mod h1:k6UKXpEg+BaDjYYXsAtZuKgP/hVO8f9J0FNViOBUkwk=
 github.com/openconfig/testt v0.0.0-20220311054427-efbb1a32ec07 h1:X631iD/B0ximGFb5P9LY5wHju4SiedxUhc5UZEo7VSw=
 github.com/openconfig/ygnmi v0.7.6 h1:zJxmfPUrkqvq1tltGRuTRlpvkXyJECLPNMmfUhWXdWY=
 github.com/openconfig/ygnmi v0.7.6/go.mod h1:qk5qX7+Wvg0U0VyCqEz5gPtaAPgXMxGPwPwzDv6zCXk=

--- a/kne/integration.testbed
+++ b/kne/integration.testbed
@@ -1,0 +1,22 @@
+# proto-file: github.com/openconfig/ondatra/blob/main/proto/testbed.proto
+# proto-message: ondatra.Testbed
+
+ates {
+  id: "ate"
+  ports {
+    id: "port1"
+  }
+  ports {
+    id: "port2"
+  }
+}
+
+duts {
+  id: "mirror"
+  ports: {
+    id: "port1"
+  }
+  ports: {
+    id: "port2"
+  }
+}

--- a/kne/integration.textproto
+++ b/kne/integration.textproto
@@ -1,0 +1,66 @@
+name: "magna-integration"
+nodes: {
+  name: "ate"
+  vendor: OPENCONFIG
+  model: "MAGNA"
+  labels: {
+    key: "ondatra-role"
+    value: "ATE"
+  }
+  config: {
+    image: "magna:latest"
+    command: "/app/magna"
+    args: "-alsologtostderr"
+    args: "-v=2"
+    args: "-port=40051"
+    args: "-telemetry_port=50051"
+    args: "-certfile=/data/cert.pem"
+    args: "-keyfile=/data/key.pem"
+  }
+  services: {
+    key: 40051
+    value: {
+      name: "grpc"
+      inside: 40051
+    }
+  }
+  services: {
+    key: 50051
+    value: {
+      name: "gnmi"
+      inside: 50051
+    }
+  }
+}
+nodes {
+  name: "mirror"
+  vendor: HOST
+  labels: {
+    key: "ondatra-role"
+    value: "DUT"
+  }
+  config {
+    image: "mirror:latest"
+    command: "/app/mirror"
+    command: "-alsologtostderr"
+  }
+  services: {
+    key: 60051
+    value: {
+      name: "mirror-controller"
+      inside: 60051
+    }
+  }
+}
+links: {
+  a_node: "ate"
+  a_int: "eth1"
+  z_node: "mirror"
+  z_int: "eth1"
+}
+links: {
+  a_node: "ate"
+  a_int: "eth2"
+  z_node: "mirror"
+  z_int : "eth2"
+}

--- a/lwotg/lwotg_test.go
+++ b/lwotg/lwotg_test.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"net"
 	"testing"
+	"time"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/open-traffic-generator/snappi/gosnappi/otg"
@@ -117,6 +118,7 @@ func TestSetControlState(t *testing.T) {
 		wantResponse: okResponse,
 		wantFn: func(t *testing.T) {
 			t.Helper()
+			time.Sleep(200 * time.Millisecond)
 			if state != "TRAFFIC_CALLED" {
 				t.Fatalf("did not get expected state, got: %s, want: TRAFFIC_CALLED", state)
 			}

--- a/mirrorsrv/mirror.go
+++ b/mirrorsrv/mirror.go
@@ -100,6 +100,7 @@ func copyPackets(from, to string, filter func(p gopacket.Packet) bool) func(chan
 		for {
 			select {
 			case <-stop:
+				klog.Infof("stopping goroutine that copies from %s->%s", from, to)
 				return
 			case p := <-ps.Packets():
 				if !filter(p) {

--- a/mirrorsrv/mirror.go
+++ b/mirrorsrv/mirror.go
@@ -104,6 +104,7 @@ func copyPackets(from, to string, filter func(p gopacket.Packet) bool) func(chan
 				return
 			case p := <-ps.Packets():
 				if !filter(p) {
+					klog.Infof("ignoring packet %v", p)
 					continue
 				}
 


### PR DESCRIPTION
This PR adds an integration test that uses the mirror service as a simple DUT to validate magna functionality.

Depends on a change in ONDATRA to treat 'host' containers as DUTs.
