### PR TITLE
Add testing support for multiple flows.

### DIFF
--- a/flows/mpls/mpls.go
+++ b/flows/mpls/mpls.go
@@ -457,11 +457,15 @@ func (f *flowCounters) setTransmit(state bool) {
 
 // clearStats zeros the stastitics for the flow.
 func (f *flowCounters) clearStats(ts int64) {
-	f.Tx.mu.Lock()
-	defer f.Tx.mu.Unlock()
+	if f.Tx != nil {
+		f.Tx.mu.Lock()
+		defer f.Tx.mu.Unlock()
+	}
 
-	f.Rx.mu.Lock()
-	defer f.Rx.mu.Unlock()
+	if f.Rx != nil {
+		f.Rx.mu.Lock()
+		defer f.Rx.mu.Unlock()
+	}
 
 	f.Tx = &stats{
 		Octets: &val{ts: ts, u: 0},

--- a/kne/integration.testbed
+++ b/kne/integration.testbed
@@ -9,15 +9,21 @@ ates {
   ports {
     id: "port2"
   }
+  ports {
+    id: "port3",
+  }
 }
 
 duts {
   id: "mirror"
-  ports: {
+  ports {
     id: "port1"
   }
-  ports: {
+  ports {
     id: "port2"
+  }
+  ports {
+    id: "port3"
   }
 }
 
@@ -29,5 +35,10 @@ links {
 links {
   a: "ate:port2"
   b: "mirror:port2"
+}
+
+links {
+  a: "ate:port3"
+  b: "mirror:port3"
 }
 

--- a/kne/integration.testbed
+++ b/kne/integration.testbed
@@ -20,3 +20,14 @@ duts {
     id: "port2"
   }
 }
+
+links {
+  a: "ate:port1"
+  b: "mirror:port1"
+}
+
+links {
+  a: "ate:port2"
+  b: "mirror:port2"
+}
+

--- a/kne/integration.textproto
+++ b/kne/integration.textproto
@@ -64,3 +64,9 @@ links: {
   z_node: "mirror"
   z_int : "eth2"
 }
+links: {
+  a_node: "ate"
+  a_int: "eth3"
+  z_node: "mirror"
+  z_int: "eth3"
+}

--- a/lwotg/flows_test.go
+++ b/lwotg/flows_test.go
@@ -52,6 +52,19 @@ func TestHandleFlows(t *testing.T) {
 		},
 		wantMethods: []TXRXFn{dummyFn, dummyFn},
 	}, {
+		desc: "duplicate flow names",
+		inFlows: []*otg.Flow{{
+			Name: "flow0",
+		}, {
+			Name: "flow0",
+		}},
+		inFns: []FlowGeneratorFn{
+			func(_ *otg.Flow, _ []*OTGIntf) (TXRXFn, bool, error) {
+				return func(tx, rx *FlowController) {}, true, nil
+			},
+		},
+		wantErrCode: codes.InvalidArgument,
+	}, {
 		desc: "flow handler that returns an error",
 		inFlows: []*otg.Flow{{
 			Name: "error",


### PR DESCRIPTION
```
commit 028559c0047f904be4b41cf4fad03a11d115b1be
Author: Rob Shakir <robjs@google.com>
Date:   Mon Aug 21 22:45:30 2023 +0000

    Add testing for `flowCounters.clearStats`.

commit f6055a16916b5bbbbbb08b40d4d780e1fc6e2596
Author: Rob Shakir <robjs@google.com>
Date:   Mon Aug 21 22:31:55 2023 +0000

    Add tests covering multiple flows within the simple e2e test.
    
     * (M) e2e/simple_ondatra_test.go
       - Refactor to have more reusability.
       - Add test cases for multiple flows, and one that does not work.
     * (M) flows/mpls/mpls.go
       - Add support for resetting counters.
     * (M) kne/integration.testbed
       - Ensure that the wiring of the testbed is consistent.
     * (M) lwotg/flows(_test)?.go
       - Ensure that we do not accept >1 flow with the same name.
```


## passing integration test results

```

I0821 22:34:44.171465   19076 topo.go:151] Trying in-cluster configuration
I0821 22:34:44.171513   19076 topo.go:154] Falling back to kubeconfig: "/usr/local/google/home/robjs/.kube/config"
I0821 22:34:44.172812   19076 topo.go:357] Adding Link: ate:eth1 mirror:eth1
I0821 22:34:44.172831   19076 topo.go:357] Adding Link: ate:eth2 mirror:eth2
I0821 22:34:44.172836   19076 topo.go:398] Adding Node: ate:OPENCONFIG
I0821 22:34:44.172875   19076 topo.go:398] Adding Node: mirror:HOST

*** Reserving the testbed...

I0821 22:34:44.173310   19076 topo.go:292] Topology:
name: "magna-integration"
nodes: {
  name: "ate"
  labels: {
    key: "ondatra-role"
    value: "ATE"
  }
  config: {
    command: "/app/magna"
    args: "-alsologtostderr"
    args: "-v=2"
    args: "-port=40051"
    args: "-telemetry_port=50051"
    args: "-certfile=/data/cert.pem"
    args: "-keyfile=/data/key.pem"
    image: "magna:latest"
    entry_command: "kubectl exec -it ate -- sh"
  }
  services: {
    key: 40051
    value: {
      name: "grpc"
      inside: 40051
    }
  }
  services: {
    key: 50051
    value: {
      name: "gnmi"
      inside: 50051
    }
  }
  vendor: OPENCONFIG
  model: "MAGNA"
  interfaces: {
    key: "eth1"
    value: {
      int_name: "eth1"
      peer_name: "mirror"
      peer_int_name: "eth1"
    }
  }
  interfaces: {
    key: "eth2"
    value: {
      int_name: "eth2"
      peer_name: "mirror"
      peer_int_name: "eth2"
      uid: 1
    }
  }
}
nodes: {
  name: "mirror"
  labels: {
    key: "ondatra-role"
    value: "DUT"
  }
  config: {
    command: "/app/mirror"
    command: "-alsologtostderr"
    image: "mirror:latest"
    entry_command: "kubectl exec -it mirror -- sh"
    config_path: "/etc"
    config_file: "config"
  }
  services: {
    key: 60051
    value: {
      name: "mirror-controller"
      inside: 60051
    }
  }
  vendor: HOST
  interfaces: {
    key: "eth1"
    value: {
      int_name: "eth1"
      peer_name: "ate"
      peer_int_name: "eth1"
    }
  }
  interfaces: {
    key: "eth2"
    value: {
      int_name: "eth2"
      peer_name: "ate"
      peer_int_name: "eth2"
      uid: 1
    }
  }
}
links: {
  a_node: "ate"
  a_int: "eth1"
  z_node: "mirror"
  z_int: "eth1"
}
links: {
  a_node: "ate"
  a_int: "eth2"
  z_node: "mirror"
  z_int: "eth2"
}
E0821 22:34:44.204576   19076 dut.go:271] Could not dial GNMI to dut mirror: service "gnmi" not found on DUT "mirror"
*** PROPERTY: build.path -> 
*** PROPERTY: build.main.version -> 
*** PROPERTY: git.origin -> git@github.com:openconfig/magna.git
*** PROPERTY: topology -> ate:2,mirror:2
*** PROPERTY: test.path -> e2e
*** PROPERTY: build.go_version -> go1.22-20230729-RC00 cl/552016856 +457721cd52 X:fieldtrack,boringcrypto
*** PROPERTY: build.main.path -> 
*** PROPERTY: build.main.sum -> 
*** PROPERTY: git.commit -> f6055a16916b5bbbbbb08b40d4d780e1fc6e2596
*** PROPERTY: git.commit_timestamp -> 1692657115
*** PROPERTY: git.status -> ?? foo

*** PROPERTY: git.clean -> false

********************************************************************************

  Testbed Reservation Complete
  ID: 1430f432-f9f9-4153-bbe0-d9a2d5323a94

    mirror:           mirror
    port1:            eth1
    port2:            eth2
    ate:              ate
    port1:            eth1
    port2:            eth2

********************************************************************************

=== RUN   TestMirror
--- PASS: TestMirror (1.00s)
=== RUN   TestMPLS
    simple_ondatra_test.go:68: 
        *** Creating new config for ate...
        
        
[WARNING]: PortName property in schema DeviceEthernet is deprecated, This property is deprecated in favor of property connection.port_name
[WARNING]: PortName property in schema DeviceEthernet is deprecated, This property is deprecated in favor of property connection.port_name
    simple_ondatra_test.go:80: configuration for OTG is {
          "ports": [
            {
              "name": "port1"
            },
            {
              "name": "port2"
            }
          ],
          "devices": [
            {
              "ethernets": [
                {
                  "port_name": "port1",
                  "mac": "02:00:01:01:01:01",
                  "mtu": 1500,
                  "name": "port1_ETH"
                }
              ],
              "name": "port1"
            },
            {
              "ethernets": [
                {
                  "port_name": "port2",
                  "mac": "02:00:02:01:01:01",
                  "mtu": 1500,
                  "name": "port2_ETH"
                }
              ],
              "name": "port2"
            }
          ]
        }
    simple_ondatra_test.go:82: 
        *** Pushing config to ate...
        
        
[WARNING]: PortName property in schema DeviceEthernet is deprecated, This property is deprecated in favor of property connection.port_name
[WARNING]: PortName property in schema DeviceEthernet is deprecated, This property is deprecated in favor of property connection.port_name
    simple_ondatra_test.go:229: 
        *** Pushing config to ate...
        
        
[WARNING]: PortName property in schema DeviceEthernet is deprecated, This property is deprecated in favor of property connection.port_name
[WARNING]: PortName property in schema DeviceEthernet is deprecated, This property is deprecated in favor of property connection.port_name
    simple_ondatra_test.go:231: Starting MPLS traffic...
    simple_ondatra_test.go:232: 
        *** Starting traffic on ate...
        
        
    simple_ondatra_test.go:233: Sleeping for 10s...
    simple_ondatra_test.go:235: Stopping MPLS traffic...
    simple_ondatra_test.go:236: 
        *** Stopping traffic on ate...
        
        
--- PASS: TestMPLS (14.06s)
=== RUN   TestMPLSFlows
=== RUN   TestMPLSFlows/two_flows_-_same_source_port
    simple_ondatra_test.go:68: 
        *** Creating new config for ate...
        
        
[WARNING]: PortName property in schema DeviceEthernet is deprecated, This property is deprecated in favor of property connection.port_name
[WARNING]: PortName property in schema DeviceEthernet is deprecated, This property is deprecated in favor of property connection.port_name
    simple_ondatra_test.go:80: configuration for OTG is {
          "ports": [
            {
              "name": "port1"
            },
            {
              "name": "port2"
            }
          ],
          "devices": [
            {
              "ethernets": [
                {
                  "port_name": "port1",
                  "mac": "02:00:01:01:01:01",
                  "mtu": 1500,
                  "name": "port1_ETH"
                }
              ],
              "name": "port1"
            },
            {
              "ethernets": [
                {
                  "port_name": "port2",
                  "mac": "02:00:02:01:01:01",
                  "mtu": 1500,
                  "name": "port2_ETH"
                }
              ],
              "name": "port2"
            }
          ]
        }
    simple_ondatra_test.go:82: 
        *** Pushing config to ate...
        
        
[WARNING]: PortName property in schema DeviceEthernet is deprecated, This property is deprecated in favor of property connection.port_name
[WARNING]: PortName property in schema DeviceEthernet is deprecated, This property is deprecated in favor of property connection.port_name
    simple_ondatra_test.go:328: 
        *** Pushing config to ate...
        
        
[WARNING]: PortName property in schema DeviceEthernet is deprecated, This property is deprecated in favor of property connection.port_name
[WARNING]: PortName property in schema DeviceEthernet is deprecated, This property is deprecated in favor of property connection.port_name
    simple_ondatra_test.go:330: Starting MPLS traffic...
    simple_ondatra_test.go:331: 
        *** Starting traffic on ate...
        
        
    simple_ondatra_test.go:332: Sleeping for 10s...
    simple_ondatra_test.go:334: Stopping MPLS traffic...
    simple_ondatra_test.go:335: 
        *** Stopping traffic on ate...
        
        
=== RUN   TestMPLSFlows/failure_-_two_flows,_one_that_is_not_mirrored
    simple_ondatra_test.go:68: 
        *** Creating new config for ate...
        
        
[WARNING]: PortName property in schema DeviceEthernet is deprecated, This property is deprecated in favor of property connection.port_name
[WARNING]: PortName property in schema DeviceEthernet is deprecated, This property is deprecated in favor of property connection.port_name
    simple_ondatra_test.go:80: configuration for OTG is {
          "ports": [
            {
              "name": "port1"
            },
            {
              "name": "port2"
            }
          ],
          "devices": [
            {
              "ethernets": [
                {
                  "port_name": "port1",
                  "mac": "02:00:01:01:01:01",
                  "mtu": 1500,
                  "name": "port1_ETH"
                }
              ],
              "name": "port1"
            },
            {
              "ethernets": [
                {
                  "port_name": "port2",
                  "mac": "02:00:02:01:01:01",
                  "mtu": 1500,
                  "name": "port2_ETH"
                }
              ],
              "name": "port2"
            }
          ]
        }
    simple_ondatra_test.go:82: 
        *** Pushing config to ate...
        
        
[WARNING]: PortName property in schema DeviceEthernet is deprecated, This property is deprecated in favor of property connection.port_name
[WARNING]: PortName property in schema DeviceEthernet is deprecated, This property is deprecated in favor of property connection.port_name
    simple_ondatra_test.go:328: 
        *** Pushing config to ate...
        
        
[WARNING]: PortName property in schema DeviceEthernet is deprecated, This property is deprecated in favor of property connection.port_name
[WARNING]: PortName property in schema DeviceEthernet is deprecated, This property is deprecated in favor of property connection.port_name
    simple_ondatra_test.go:330: Starting MPLS traffic...
    simple_ondatra_test.go:331: 
        *** Starting traffic on ate...
        
        
    simple_ondatra_test.go:332: Sleeping for 10s...
    simple_ondatra_test.go:334: Stopping MPLS traffic...
    simple_ondatra_test.go:335: 
        *** Stopping traffic on ate...
        
        
=== RUN   TestMPLSFlows/ten_flows
    simple_ondatra_test.go:68: 
        *** Creating new config for ate...
        
        
[WARNING]: PortName property in schema DeviceEthernet is deprecated, This property is deprecated in favor of property connection.port_name
[WARNING]: PortName property in schema DeviceEthernet is deprecated, This property is deprecated in favor of property connection.port_name
    simple_ondatra_test.go:80: configuration for OTG is {
          "ports": [
            {
              "name": "port1"
            },
            {
              "name": "port2"
            }
          ],
          "devices": [
            {
              "ethernets": [
                {
                  "port_name": "port1",
                  "mac": "02:00:01:01:01:01",
                  "mtu": 1500,
                  "name": "port1_ETH"
                }
              ],
              "name": "port1"
            },
            {
              "ethernets": [
                {
                  "port_name": "port2",
                  "mac": "02:00:02:01:01:01",
                  "mtu": 1500,
                  "name": "port2_ETH"
                }
              ],
              "name": "port2"
            }
          ]
        }
    simple_ondatra_test.go:82: 
        *** Pushing config to ate...
        
        
[WARNING]: PortName property in schema DeviceEthernet is deprecated, This property is deprecated in favor of property connection.port_name
[WARNING]: PortName property in schema DeviceEthernet is deprecated, This property is deprecated in favor of property connection.port_name
    simple_ondatra_test.go:328: 
        *** Pushing config to ate...
        
        
[WARNING]: PortName property in schema DeviceEthernet is deprecated, This property is deprecated in favor of property connection.port_name
[WARNING]: PortName property in schema DeviceEthernet is deprecated, This property is deprecated in favor of property connection.port_name
    simple_ondatra_test.go:330: Starting MPLS traffic...
    simple_ondatra_test.go:331: 
        *** Starting traffic on ate...
        
        
    simple_ondatra_test.go:332: Sleeping for 10s...
    simple_ondatra_test.go:334: Stopping MPLS traffic...
    simple_ondatra_test.go:335: 
        *** Stopping traffic on ate...
        
        
--- PASS: TestMPLSFlows (47.13s)
    --- PASS: TestMPLSFlows/two_flows_-_same_source_port (14.04s)
    --- PASS: TestMPLSFlows/failure_-_two_flows,_one_that_is_not_mirrored (15.04s)
    --- PASS: TestMPLSFlows/ten_flows (18.05s)
PASS

*** Releasing the testbed...

*** PROPERTY: time.begin -> 1692657284
*** PROPERTY: time.end -> 1692657346
ok  	command-line-arguments	63.410s
```
