### PR TITLE
Add support for N:1 traffic tests.

### DIFF
--- a/kne/integration.testbed
+++ b/kne/integration.testbed
@@ -9,15 +9,21 @@ ates {
   ports {
     id: "port2"
   }
+  ports {
+    id: "port3",
+  }
 }
 
 duts {
   id: "mirror"
-  ports: {
+  ports {
     id: "port1"
   }
-  ports: {
+  ports {
     id: "port2"
+  }
+  ports {
+    id: "port3"
   }
 }
 
@@ -29,5 +35,10 @@ links {
 links {
   a: "ate:port2"
   b: "mirror:port2"
+}
+
+links {
+  a: "ate:port3"
+  b: "mirror:port3"
 }
 

--- a/kne/integration.textproto
+++ b/kne/integration.textproto
@@ -64,3 +64,9 @@ links: {
   z_node: "mirror"
   z_int : "eth2"
 }
+links: {
+  a_node: "ate"
+  a_int: "eth3"
+  z_node: "mirror"
+  z_int: "eth3"
+}


### PR DESCRIPTION
```
commit 6b54c2a47c02712d305aab848fc56932bdab66ef
Author: Rob Shakir <robjs@google.com>
Date:   Mon Aug 21 23:43:00 2023 +0000

    Add multiple destination flows at a port and testing.
    
     * (M) kne/*
       - Update the integration testbeds.
     * (M) e2e/simple_ondatra_test.go
       - Add testing to ensure that multiple flows can be received at each
         port.

commit 1d451de250c5f66f976285b116eb04e2b91ba482
Author: Rob Shakir <robjs@google.com>
Date:   Tue Aug 22 00:50:21 2023 +0000

    Improve logging and parallelise stopping traffic.
```

The change to the `stopTraffic` function is to ensure that there is not a 1s
blocking period whilst waiting for the traffic sender to check the channel when
stopping traffic. This made tests results look strange because flows that were
started later ended up running for N seconds longer :-)

## passing test results

```
I0822 00:47:13.537167   14369 topo.go:151] Trying in-cluster configuration
I0822 00:47:13.537216   14369 topo.go:154] Falling back to kubeconfig: "/usr/local/google/home/robjs/.kube/config"
I0822 00:47:13.538490   14369 topo.go:357] Adding Link: ate:eth1 mirror:eth1
I0822 00:47:13.538509   14369 topo.go:357] Adding Link: ate:eth2 mirror:eth2
I0822 00:47:13.538513   14369 topo.go:357] Adding Link: ate:eth3 mirror:eth3
I0822 00:47:13.538518   14369 topo.go:398] Adding Node: ate:OPENCONFIG
I0822 00:47:13.538547   14369 topo.go:398] Adding Node: mirror:HOST

*** Reserving the testbed...

I0822 00:47:13.539043   14369 topo.go:292] Topology:
name:  "magna-integration"
nodes:  {
  name:  "ate"
  labels:  {
    key:  "ondatra-role"
    value:  "ATE"
  }
  config:  {
    command:  "/app/magna"
    args:  "-alsologtostderr"
    args:  "-v=2"
    args:  "-port=40051"
    args:  "-telemetry_port=50051"
    args:  "-certfile=/data/cert.pem"
    args:  "-keyfile=/data/key.pem"
    image:  "magna:latest"
    entry_command:  "kubectl exec -it ate -- sh"
  }
  services:  {
    key:  40051
    value:  {
      name:  "grpc"
      inside:  40051
    }
  }
  services:  {
    key:  50051
    value:  {
      name:  "gnmi"
      inside:  50051
    }
  }
  vendor:  OPENCONFIG
  model:  "MAGNA"
  interfaces:  {
    key:  "eth1"
    value:  {
      int_name:  "eth1"
      peer_name:  "mirror"
      peer_int_name:  "eth1"
    }
  }
  interfaces:  {
    key:  "eth2"
    value:  {
      int_name:  "eth2"
      peer_name:  "mirror"
      peer_int_name:  "eth2"
      uid:  1
    }
  }
  interfaces:  {
    key:  "eth3"
    value:  {
      int_name:  "eth3"
      peer_name:  "mirror"
      peer_int_name:  "eth3"
      uid:  2
    }
  }
}
nodes:  {
  name:  "mirror"
  labels:  {
    key:  "ondatra-role"
    value:  "DUT"
  }
  config:  {
    command:  "/app/mirror"
    command:  "-alsologtostderr"
    image:  "mirror:latest"
    entry_command:  "kubectl exec -it mirror -- sh"
    config_path:  "/etc"
    config_file:  "config"
  }
  services:  {
    key:  60051
    value:  {
      name:  "mirror-controller"
      inside:  60051
    }
  }
  vendor:  HOST
  interfaces:  {
    key:  "eth1"
    value:  {
      int_name:  "eth1"
      peer_name:  "ate"
      peer_int_name:  "eth1"
    }
  }
  interfaces:  {
    key:  "eth2"
    value:  {
      int_name:  "eth2"
      peer_name:  "ate"
      peer_int_name:  "eth2"
      uid:  1
    }
  }
  interfaces:  {
    key:  "eth3"
    value:  {
      int_name:  "eth3"
      peer_name:  "ate"
      peer_int_name:  "eth3"
      uid:  2
    }
  }
}
links:  {
  a_node:  "ate"
  a_int:  "eth1"
  z_node:  "mirror"
  z_int:  "eth1"
}
links:  {
  a_node:  "ate"
  a_int:  "eth2"
  z_node:  "mirror"
  z_int:  "eth2"
}
links:  {
  a_node:  "ate"
  a_int:  "eth3"
  z_node:  "mirror"
  z_int:  "eth3"
}
E0822 00:47:13.573333   14369 dut.go:271] Could not dial GNMI to dut mirror: service "gnmi" not found on DUT "mirror"
*** PROPERTY: build.main.path -> 
*** PROPERTY: git.commit_timestamp -> 1692661380
*** PROPERTY: git.status -> ?? foo
?? log
 M lwotg/flows.go
?? ate.log
 M flows/mpls/mpls.go

*** PROPERTY: topology -> ate:3,mirror:3
*** PROPERTY: git.origin -> git@github.com:openconfig/magna.git
*** PROPERTY: git.commit -> 6b54c2a47c02712d305aab848fc56932bdab66ef
*** PROPERTY: git.clean -> false
*** PROPERTY: test.path -> e2e
*** PROPERTY: build.go_version -> go1.22-20230729-RC00 cl/552016856 +457721cd52 X:fieldtrack,boringcrypto
*** PROPERTY: build.path -> 
*** PROPERTY: build.main.version -> 
*** PROPERTY: build.main.sum -> 

********************************************************************************

  Testbed Reservation Complete
  ID: 46e91198-da87-433a-8a5f-e5e123dd4812

    mirror:           mirror
    port1:            eth3
    port2:            eth1
    port3:            eth2
    ate:              ate
    port1:            eth3
    port2:            eth1
    port3:            eth2

********************************************************************************

=== RUN   TestMirror
--- PASS: TestMirror (1.00s)
=== RUN   TestMPLS
    simple_ondatra_test.go:73: 
        *** Creating new config for ate...
        
        
[WARNING]: PortName property in schema DeviceEthernet is deprecated, This property is deprecated in favor of property connection.port_name
[WARNING]: PortName property in schema DeviceEthernet is deprecated, This property is deprecated in favor of property connection.port_name
[WARNING]: PortName property in schema DeviceEthernet is deprecated, This property is deprecated in favor of property connection.port_name
    simple_ondatra_test.go:85: configuration for OTG is {
          "ports":  [
            {
              "name":  "port1"
            },
            {
              "name":  "port2"
            },
            {
              "name":  "port3"
            }
          ],
          "devices":  [
            {
              "ethernets":  [
                {
                  "port_name":  "port1",
                  "mac":  "02:00:01:01:01:01",
                  "mtu":  1500,
                  "name":  "port1_ETH"
                }
              ],
              "name":  "port1"
            },
            {
              "ethernets":  [
                {
                  "port_name":  "port2",
                  "mac":  "02:00:02:01:01:01",
                  "mtu":  1500,
                  "name":  "port2_ETH"
                }
              ],
              "name":  "port2"
            },
            {
              "ethernets":  [
                {
                  "port_name":  "port3",
                  "mac":  "03:00:03:01:01:01",
                  "mtu":  1500,
                  "name":  "port3_ETH"
                }
              ],
              "name":  "port3"
            }
          ]
        }
    simple_ondatra_test.go:87: 
        *** Pushing config to ate...
        
        
[WARNING]: PortName property in schema DeviceEthernet is deprecated, This property is deprecated in favor of property connection.port_name
[WARNING]: PortName property in schema DeviceEthernet is deprecated, This property is deprecated in favor of property connection.port_name
[WARNING]: PortName property in schema DeviceEthernet is deprecated, This property is deprecated in favor of property connection.port_name
    simple_ondatra_test.go:245: 
        *** Pushing config to ate...
        
        
[WARNING]: PortName property in schema DeviceEthernet is deprecated, This property is deprecated in favor of property connection.port_name
[WARNING]: PortName property in schema DeviceEthernet is deprecated, This property is deprecated in favor of property connection.port_name
[WARNING]: PortName property in schema DeviceEthernet is deprecated, This property is deprecated in favor of property connection.port_name
    simple_ondatra_test.go:247: Starting MPLS traffic...
    simple_ondatra_test.go:248: 
        *** Starting traffic on ate...
        
        
    simple_ondatra_test.go:249: Sleeping for 10s...
    simple_ondatra_test.go:251: Stopping MPLS traffic...
    simple_ondatra_test.go:252: 
        *** Stopping traffic on ate...
        
        
--- PASS: TestMPLS (14.06s)
=== RUN   TestMPLSFlowsTwoPorts
=== RUN   TestMPLSFlowsTwoPorts/two_flows_-_same_source_port
    simple_ondatra_test.go:73: 
        *** Creating new config for ate...
        
        
[WARNING]: PortName property in schema DeviceEthernet is deprecated, This property is deprecated in favor of property connection.port_name
[WARNING]: PortName property in schema DeviceEthernet is deprecated, This property is deprecated in favor of property connection.port_name
[WARNING]: PortName property in schema DeviceEthernet is deprecated, This property is deprecated in favor of property connection.port_name
    simple_ondatra_test.go:85: configuration for OTG is {
          "ports":  [
            {
              "name":  "port1"
            },
            {
              "name":  "port2"
            },
            {
              "name":  "port3"
            }
          ],
          "devices":  [
            {
              "ethernets":  [
                {
                  "port_name":  "port1",
                  "mac":  "02:00:01:01:01:01",
                  "mtu":  1500,
                  "name":  "port1_ETH"
                }
              ],
              "name":  "port1"
            },
            {
              "ethernets":  [
                {
                  "port_name":  "port2",
                  "mac":  "02:00:02:01:01:01",
                  "mtu":  1500,
                  "name":  "port2_ETH"
                }
              ],
              "name":  "port2"
            },
            {
              "ethernets":  [
                {
                  "port_name":  "port3",
                  "mac":  "03:00:03:01:01:01",
                  "mtu":  1500,
                  "name":  "port3_ETH"
                }
              ],
              "name":  "port3"
            }
          ]
        }
    simple_ondatra_test.go:87: 
        *** Pushing config to ate...
        
        
[WARNING]: PortName property in schema DeviceEthernet is deprecated, This property is deprecated in favor of property connection.port_name
[WARNING]: PortName property in schema DeviceEthernet is deprecated, This property is deprecated in favor of property connection.port_name
[WARNING]: PortName property in schema DeviceEthernet is deprecated, This property is deprecated in favor of property connection.port_name
    simple_ondatra_test.go:345: 
        *** Pushing config to ate...
        
        
[WARNING]: PortName property in schema DeviceEthernet is deprecated, This property is deprecated in favor of property connection.port_name
[WARNING]: PortName property in schema DeviceEthernet is deprecated, This property is deprecated in favor of property connection.port_name
[WARNING]: PortName property in schema DeviceEthernet is deprecated, This property is deprecated in favor of property connection.port_name
    simple_ondatra_test.go:347: Starting MPLS traffic...
    simple_ondatra_test.go:348: 
        *** Starting traffic on ate...
        
        
    simple_ondatra_test.go:349: Sleeping for 10s...
    simple_ondatra_test.go:351: Stopping MPLS traffic...
    simple_ondatra_test.go:352: 
        *** Stopping traffic on ate...
        
        
    simple_ondatra_test.go:297: FLOW_ONE: recv: 9, sent: 10 packets
    simple_ondatra_test.go:297: FLOW_TWO: recv: 10, sent: 10 packets
=== RUN   TestMPLSFlowsTwoPorts/failure_-_two_flows,_one_that_is_not_mirrored
    simple_ondatra_test.go:73: 
        *** Creating new config for ate...
        
        
[WARNING]: PortName property in schema DeviceEthernet is deprecated, This property is deprecated in favor of property connection.port_name
[WARNING]: PortName property in schema DeviceEthernet is deprecated, This property is deprecated in favor of property connection.port_name
[WARNING]: PortName property in schema DeviceEthernet is deprecated, This property is deprecated in favor of property connection.port_name
    simple_ondatra_test.go:85: configuration for OTG is {
          "ports":  [
            {
              "name":  "port1"
            },
            {
              "name":  "port2"
            },
            {
              "name":  "port3"
            }
          ],
          "devices":  [
            {
              "ethernets":  [
                {
                  "port_name":  "port1",
                  "mac":  "02:00:01:01:01:01",
                  "mtu":  1500,
                  "name":  "port1_ETH"
                }
              ],
              "name":  "port1"
            },
            {
              "ethernets":  [
                {
                  "port_name":  "port2",
                  "mac":  "02:00:02:01:01:01",
                  "mtu":  1500,
                  "name":  "port2_ETH"
                }
              ],
              "name":  "port2"
            },
            {
              "ethernets":  [
                {
                  "port_name":  "port3",
                  "mac":  "03:00:03:01:01:01",
                  "mtu":  1500,
                  "name":  "port3_ETH"
                }
              ],
              "name":  "port3"
            }
          ]
        }
    simple_ondatra_test.go:87: 
        *** Pushing config to ate...
        
        
[WARNING]: PortName property in schema DeviceEthernet is deprecated, This property is deprecated in favor of property connection.port_name
[WARNING]: PortName property in schema DeviceEthernet is deprecated, This property is deprecated in favor of property connection.port_name
[WARNING]: PortName property in schema DeviceEthernet is deprecated, This property is deprecated in favor of property connection.port_name
    simple_ondatra_test.go:345: 
        *** Pushing config to ate...
        
        
[WARNING]: PortName property in schema DeviceEthernet is deprecated, This property is deprecated in favor of property connection.port_name
[WARNING]: PortName property in schema DeviceEthernet is deprecated, This property is deprecated in favor of property connection.port_name
[WARNING]: PortName property in schema DeviceEthernet is deprecated, This property is deprecated in favor of property connection.port_name
    simple_ondatra_test.go:347: Starting MPLS traffic...
    simple_ondatra_test.go:348: 
        *** Starting traffic on ate...
        
        
    simple_ondatra_test.go:349: Sleeping for 10s...
    simple_ondatra_test.go:351: Stopping MPLS traffic...
    simple_ondatra_test.go:352: 
        *** Stopping traffic on ate...
        
        
    simple_ondatra_test.go:307: A->B: recv: 10, sent: 10 packets
    simple_ondatra_test.go:308: B->A: recv: 0, sent: 10 packets
=== RUN   TestMPLSFlowsTwoPorts/ten_flows
    simple_ondatra_test.go:73: 
        *** Creating new config for ate...
        
        
[WARNING]: PortName property in schema DeviceEthernet is deprecated, This property is deprecated in favor of property connection.port_name
[WARNING]: PortName property in schema DeviceEthernet is deprecated, This property is deprecated in favor of property connection.port_name
[WARNING]: PortName property in schema DeviceEthernet is deprecated, This property is deprecated in favor of property connection.port_name
    simple_ondatra_test.go:85: configuration for OTG is {
          "ports":  [
            {
              "name":  "port1"
            },
            {
              "name":  "port2"
            },
            {
              "name":  "port3"
            }
          ],
          "devices":  [
            {
              "ethernets":  [
                {
                  "port_name":  "port1",
                  "mac":  "02:00:01:01:01:01",
                  "mtu":  1500,
                  "name":  "port1_ETH"
                }
              ],
              "name":  "port1"
            },
            {
              "ethernets":  [
                {
                  "port_name":  "port2",
                  "mac":  "02:00:02:01:01:01",
                  "mtu":  1500,
                  "name":  "port2_ETH"
                }
              ],
              "name":  "port2"
            },
            {
              "ethernets":  [
                {
                  "port_name":  "port3",
                  "mac":  "03:00:03:01:01:01",
                  "mtu":  1500,
                  "name":  "port3_ETH"
                }
              ],
              "name":  "port3"
            }
          ]
        }
    simple_ondatra_test.go:87: 
        *** Pushing config to ate...
        
        
[WARNING]: PortName property in schema DeviceEthernet is deprecated, This property is deprecated in favor of property connection.port_name
[WARNING]: PortName property in schema DeviceEthernet is deprecated, This property is deprecated in favor of property connection.port_name
[WARNING]: PortName property in schema DeviceEthernet is deprecated, This property is deprecated in favor of property connection.port_name
    simple_ondatra_test.go:345: 
        *** Pushing config to ate...
        
        
[WARNING]: PortName property in schema DeviceEthernet is deprecated, This property is deprecated in favor of property connection.port_name
[WARNING]: PortName property in schema DeviceEthernet is deprecated, This property is deprecated in favor of property connection.port_name
[WARNING]: PortName property in schema DeviceEthernet is deprecated, This property is deprecated in favor of property connection.port_name
    simple_ondatra_test.go:347: Starting MPLS traffic...
    simple_ondatra_test.go:348: 
        *** Starting traffic on ate...
        
        
    simple_ondatra_test.go:349: Sleeping for 10s...
    simple_ondatra_test.go:351: Stopping MPLS traffic...
    simple_ondatra_test.go:352: 
        *** Stopping traffic on ate...
        
        
    simple_ondatra_test.go:324: flow0: recv: 10, sent: 10 packets
    simple_ondatra_test.go:324: flow1: recv: 10, sent: 10 packets
    simple_ondatra_test.go:324: flow2: recv: 10, sent: 10 packets
    simple_ondatra_test.go:324: flow3: recv: 10, sent: 10 packets
    simple_ondatra_test.go:324: flow4: recv: 10, sent: 10 packets
    simple_ondatra_test.go:324: flow5: recv: 10, sent: 10 packets
    simple_ondatra_test.go:324: flow6: recv: 10, sent: 10 packets
    simple_ondatra_test.go:324: flow7: recv: 9, sent: 10 packets
    simple_ondatra_test.go:324: flow8: recv: 9, sent: 10 packets
    simple_ondatra_test.go:324: flow9: recv: 10, sent: 10 packets
--- PASS: TestMPLSFlowsTwoPorts (42.18s)
    --- PASS: TestMPLSFlowsTwoPorts/two_flows_-_same_source_port (14.05s)
    --- PASS: TestMPLSFlowsTwoPorts/failure_-_two_flows,_one_that_is_not_mirrored (14.06s)
    --- PASS: TestMPLSFlowsTwoPorts/ten_flows (14.08s)
=== RUN   TestMPLSFlowsThreePorts
=== RUN   TestMPLSFlowsThreePorts/one_flow_each
    simple_ondatra_test.go:73: 
        *** Creating new config for ate...
        
        
[WARNING]: PortName property in schema DeviceEthernet is deprecated, This property is deprecated in favor of property connection.port_name
[WARNING]: PortName property in schema DeviceEthernet is deprecated, This property is deprecated in favor of property connection.port_name
[WARNING]: PortName property in schema DeviceEthernet is deprecated, This property is deprecated in favor of property connection.port_name
    simple_ondatra_test.go:85: configuration for OTG is {
          "ports":  [
            {
              "name":  "port1"
            },
            {
              "name":  "port2"
            },
            {
              "name":  "port3"
            }
          ],
          "devices":  [
            {
              "ethernets":  [
                {
                  "port_name":  "port1",
                  "mac":  "02:00:01:01:01:01",
                  "mtu":  1500,
                  "name":  "port1_ETH"
                }
              ],
              "name":  "port1"
            },
            {
              "ethernets":  [
                {
                  "port_name":  "port2",
                  "mac":  "02:00:02:01:01:01",
                  "mtu":  1500,
                  "name":  "port2_ETH"
                }
              ],
              "name":  "port2"
            },
            {
              "ethernets":  [
                {
                  "port_name":  "port3",
                  "mac":  "03:00:03:01:01:01",
                  "mtu":  1500,
                  "name":  "port3_ETH"
                }
              ],
              "name":  "port3"
            }
          ]
        }
    simple_ondatra_test.go:87: 
        *** Pushing config to ate...
        
        
[WARNING]: PortName property in schema DeviceEthernet is deprecated, This property is deprecated in favor of property connection.port_name
[WARNING]: PortName property in schema DeviceEthernet is deprecated, This property is deprecated in favor of property connection.port_name
[WARNING]: PortName property in schema DeviceEthernet is deprecated, This property is deprecated in favor of property connection.port_name
    simple_ondatra_test.go:448: 
        *** Pushing config to ate...
        
        
[WARNING]: PortName property in schema DeviceEthernet is deprecated, This property is deprecated in favor of property connection.port_name
[WARNING]: PortName property in schema DeviceEthernet is deprecated, This property is deprecated in favor of property connection.port_name
[WARNING]: PortName property in schema DeviceEthernet is deprecated, This property is deprecated in favor of property connection.port_name
    simple_ondatra_test.go:450: Starting MPLS traffic...
    simple_ondatra_test.go:451: 
        *** Starting traffic on ate...
        
        
    simple_ondatra_test.go:452: Sleeping for 10s...
    simple_ondatra_test.go:454: Stopping MPLS traffic...
    simple_ondatra_test.go:455: 
        *** Stopping traffic on ate...
        
        
    simple_ondatra_test.go:412: port1->port2: recv: 10, sent: 10 packets
    simple_ondatra_test.go:412: port3->port2: recv: 10, sent: 10 packets
=== RUN   TestMPLSFlowsThreePorts/ten_flows_on_each_port
    simple_ondatra_test.go:73: 
        *** Creating new config for ate...
        
        
[WARNING]: PortName property in schema DeviceEthernet is deprecated, This property is deprecated in favor of property connection.port_name
[WARNING]: PortName property in schema DeviceEthernet is deprecated, This property is deprecated in favor of property connection.port_name
[WARNING]: PortName property in schema DeviceEthernet is deprecated, This property is deprecated in favor of property connection.port_name
    simple_ondatra_test.go:85: configuration for OTG is {
          "ports":  [
            {
              "name":  "port1"
            },
            {
              "name":  "port2"
            },
            {
              "name":  "port3"
            }
          ],
          "devices":  [
            {
              "ethernets":  [
                {
                  "port_name":  "port1",
                  "mac":  "02:00:01:01:01:01",
                  "mtu":  1500,
                  "name":  "port1_ETH"
                }
              ],
              "name":  "port1"
            },
            {
              "ethernets":  [
                {
                  "port_name":  "port2",
                  "mac":  "02:00:02:01:01:01",
                  "mtu":  1500,
                  "name":  "port2_ETH"
                }
              ],
              "name":  "port2"
            },
            {
              "ethernets":  [
                {
                  "port_name":  "port3",
                  "mac":  "03:00:03:01:01:01",
                  "mtu":  1500,
                  "name":  "port3_ETH"
                }
              ],
              "name":  "port3"
            }
          ]
        }
    simple_ondatra_test.go:87: 
        *** Pushing config to ate...
        
        
[WARNING]: PortName property in schema DeviceEthernet is deprecated, This property is deprecated in favor of property connection.port_name
[WARNING]: PortName property in schema DeviceEthernet is deprecated, This property is deprecated in favor of property connection.port_name
[WARNING]: PortName property in schema DeviceEthernet is deprecated, This property is deprecated in favor of property connection.port_name
    simple_ondatra_test.go:448: 
        *** Pushing config to ate...
        
        
[WARNING]: PortName property in schema DeviceEthernet is deprecated, This property is deprecated in favor of property connection.port_name
[WARNING]: PortName property in schema DeviceEthernet is deprecated, This property is deprecated in favor of property connection.port_name
[WARNING]: PortName property in schema DeviceEthernet is deprecated, This property is deprecated in favor of property connection.port_name
    simple_ondatra_test.go:450: Starting MPLS traffic...
    simple_ondatra_test.go:451: 
        *** Starting traffic on ate...
        
        
    simple_ondatra_test.go:452: Sleeping for 10s...
    simple_ondatra_test.go:454: Stopping MPLS traffic...
    simple_ondatra_test.go:455: 
        *** Stopping traffic on ate...
        
        
    simple_ondatra_test.go:426: port1->port2_0: recv: 9, sent: 10 packets
    simple_ondatra_test.go:426: port3->port2_0: recv: 9, sent: 10 packets
    simple_ondatra_test.go:426: port1->port2_1: recv: 9, sent: 10 packets
    simple_ondatra_test.go:426: port3->port2_1: recv: 10, sent: 10 packets
    simple_ondatra_test.go:426: port1->port2_2: recv: 9, sent: 10 packets
    simple_ondatra_test.go:426: port3->port2_2: recv: 9, sent: 10 packets
    simple_ondatra_test.go:426: port1->port2_3: recv: 9, sent: 10 packets
    simple_ondatra_test.go:426: port3->port2_3: recv: 10, sent: 10 packets
    simple_ondatra_test.go:426: port1->port2_4: recv: 10, sent: 10 packets
    simple_ondatra_test.go:426: port3->port2_4: recv: 9, sent: 10 packets
    simple_ondatra_test.go:426: port1->port2_5: recv: 9, sent: 10 packets
    simple_ondatra_test.go:426: port3->port2_5: recv: 9, sent: 10 packets
    simple_ondatra_test.go:426: port1->port2_6: recv: 9, sent: 10 packets
    simple_ondatra_test.go:426: port3->port2_6: recv: 9, sent: 10 packets
    simple_ondatra_test.go:426: port1->port2_7: recv: 9, sent: 10 packets
    simple_ondatra_test.go:426: port3->port2_7: recv: 9, sent: 10 packets
    simple_ondatra_test.go:426: port1->port2_8: recv: 9, sent: 10 packets
    simple_ondatra_test.go:426: port3->port2_8: recv: 10, sent: 10 packets
    simple_ondatra_test.go:426: port1->port2_9: recv: 9, sent: 10 packets
    simple_ondatra_test.go:426: port3->port2_9: recv: 10, sent: 10 packets
--- PASS: TestMPLSFlowsThreePorts (28.18s)
    --- PASS: TestMPLSFlowsThreePorts/one_flow_each (14.05s)
    --- PASS: TestMPLSFlowsThreePorts/ten_flows_on_each_port (14.13s)
PASS

*** Releasing the testbed...

*** PROPERTY: time.begin -> 1692665233
*** PROPERTY: time.end -> 1692665318
ok  	command-line-arguments	86.663s
```
