### PR TITLE
Support both RxName and RxNames.

### DIFF
--- a/flows/common/common.go
+++ b/flows/common/common.go
@@ -17,11 +17,19 @@ func Ports(flow *otg.Flow, intfs []*lwotg.OTGIntf) (tx string, rx string, err er
 	}
 
 	txName := flow.GetTxRx().GetPort().GetTxName()
-	if rxList := flow.GetTxRx().GetPort().GetRxNames(); len(rxList) != 1 {
+	var rxName string
+	switch rxList := flow.GetTxRx().GetPort().GetRxNames(); len(rxList) {
+	case 0:
+		rxName = flow.GetTxRx().GetPort().GetRxName()
+		if rxName == "" {
+			return "", "", fmt.Errorf("flows specified single port, but it was not specified")
+		}
+	case 1:
+		rxName = flow.GetTxRx().GetPort().GetRxNames()[0]
+	default:
 		return "", "", fmt.Errorf("flows received at multiple ports are not supported, got: %d ports (%v)", len(rxList), rxList)
 
 	}
-	rxName := flow.GetTxRx().GetPort().GetRxNames()[0]
 
 	for _, i := range intfs {
 		if i.OTGPortName == txName {

--- a/flows/common/common_test.go
+++ b/flows/common/common_test.go
@@ -60,6 +60,26 @@ func TestPorts(t *testing.T) {
 		wantTx: "eth0",
 		wantRx: "eth1",
 	}, {
+		desc: "valid legacy specification",
+		inFlow: &otg.Flow{
+			TxRx: &otg.FlowTxRx{
+				Choice: &portValue,
+				Port: &otg.FlowPort{
+					TxName: "port1",
+					RxName: proto.String("port2"), // Note, this field is to be deprecated.
+				},
+			},
+		},
+		inIntfs: []*lwotg.OTGIntf{{
+			OTGPortName: "port1",
+			SystemName:  "eth0",
+		}, {
+			OTGPortName: "port2",
+			SystemName:  "eth1",
+		}},
+		wantTx: "eth0",
+		wantRx: "eth1",
+	}, {
 		desc: "multiple rx ports",
 		inFlow: &otg.Flow{
 			TxRx: &otg.FlowTxRx{


### PR DESCRIPTION
```
* (M) flows/common/*
   - OTG is removing support for RxName, but some clients are not yet
     migrated (i.e., this field has not been deprecated) so both must be
     supported.
```
