### PR TITLE
Add support for BPF packet filtering.

### DIFF
--- a/e2e/simple_ondatra_test.go
+++ b/e2e/simple_ondatra_test.go
@@ -249,7 +249,9 @@ func TestBasicMPLS(t *testing.T) {
 
 	otg := ondatra.ATE(t, "ate").OTG()
 	otgCfg.Flows().Clear().Items()
-	addMPLSFlow(t, otgCfg, "MPLS_FLOW", ateSrc.Name, ateDst.Name, "100.64.1.1", "100.64.1.2", 1, 5)
+	packets := uint32((*sleepTime).Seconds() * 0.9)
+	t.Logf("sending %d packets in %s", packets, *sleepTime)
+	addMPLSFlow(t, otgCfg, "MPLS_FLOW", ateSrc.Name, ateDst.Name, "100.64.1.1", "100.64.1.2", 1, packets)
 
 	otg.PushConfig(t, otgCfg)
 


### PR DESCRIPTION
```
* (M) flows/common/*
   - Add a new means to specify a function that returns a BPF filter for
     a specific flow, allowing magna to avoid parsing packets for every
     input packet on every flow.
  * (M) flows/mpls/*
    - Generate BPF filter for MPLS packets. This requires offset
      matching to match multiple MPLS layers.
  * (M) flows/ip/*
    - Generate BPF filter for IP packets.
```

Created tracking issues for adding IPv[46] `packetInFlow` and e2e tests that are
missing from the checked in code. To be added in a subsequent PR.
