### PR TITLE
Allow overriding port and network accessor interfaces

### DIFF
--- a/flows/common/common.go
+++ b/flows/common/common.go
@@ -42,9 +42,10 @@ type Port interface {
 	WritePacketData(data []byte) error
 	// Close closes the port.
 	Close()
-	// LinkType the layer which packet are processed.
+	// LinkType specifies the layer at which packet written to the port are processed.
 	LinkType() layers.LinkType
-	// SetSetBPFFilter sets the filter.
+	// SetBPFFilter sets a Berkeley Packet Filtering (BPF) filter for the port.
+	// When specified, only packets matching the BPF filter are read from the port.
 	SetBPFFilter(string) error
 }
 

--- a/flows/common/common.go
+++ b/flows/common/common.go
@@ -208,9 +208,9 @@ func Handler(fn hdrsFunc, bpfFn bpfFunc, match matchFunc, reporter *Reporter) lw
 
 		recvFunc := func(controllerID string, stop, readyForTx chan struct{}) {
 			klog.Infof("%s receive function started on interface %s", flow.GetName(), rx)
-			port, err := handleCreator.CreateHandle(rx)
+			handle, err := handleCreator.CreateHandle(rx)
 			if err != nil {
-				klog.Errorf("cannot create port, err: %v", err)
+				klog.Errorf("cannot create handle, err: %v", err)
 				return
 			}
 
@@ -224,13 +224,13 @@ func Handler(fn hdrsFunc, bpfFn bpfFunc, match matchFunc, reporter *Reporter) lw
 			case filter == "":
 				klog.Warningf("%s: filter was nil, all goroutines will receive all packets, possible scale reduction", flow.GetName())
 			default:
-				if err := port.SetBPFFilter(filter); err != nil {
+				if err := handle.SetBPFFilter(filter); err != nil {
 					klog.Errorf("%s: cannot set packet filter, err: %v", flow.GetName(), err)
 					return
 				}
 			}
 
-			ps := gopacket.NewPacketSource(port, port.LinkType())
+			ps := gopacket.NewPacketSource(handle, handle.LinkType())
 			packetCh := ps.Packets()
 			f := reporter.Flow(flow.GetName())
 

--- a/intf/intf.go
+++ b/intf/intf.go
@@ -262,3 +262,8 @@ const (
 func InterfaceState(name string, state IntState) error {
 	return accessor.InterfaceState(name, state)
 }
+
+// OverrideAccessor overrides the package network accessor to custom implementation.
+func OverrideAccessor(acc NetworkAccessor) {
+	accessor = acc
+}


### PR DESCRIPTION
I'm working on a pure userspace test with lemming + magna.  I need to be able to set custom implementations of the port and netlink API.
 The solution here is supposed to be minimal invasive, alternatively I could propagate the interface through all the structs to let external users defined custom implementations of the port and netlink APIs.