### PR TITLE
Add static TTLs for IPv[46] flows.

### DIFF
--- a/flows/ip/ip.go
+++ b/flows/ip/ip.go
@@ -132,6 +132,7 @@ func headers(f *otg.Flow) ([]gopacket.SerializableLayer, error) {
 				SrcIP:   srcIP,
 				DstIP:   dstIP,
 				Version: 4,
+				TTL:     32,
 			})
 	case ip6 != nil:
 		if dstT := ip6.GetIpv6().GetDst().GetChoice(); dstT != otg.PatternFlowIpv6Dst_Choice_value {
@@ -160,9 +161,10 @@ func headers(f *otg.Flow) ([]gopacket.SerializableLayer, error) {
 			EthernetType: layers.EthernetTypeIPv6,
 		},
 			&layers.IPv6{
-				SrcIP:   srcIP,
-				DstIP:   dstIP,
-				Version: 6,
+				SrcIP:    srcIP,
+				DstIP:    dstIP,
+				Version:  6,
+				HopLimit: 32,
 			})
 	}
 

--- a/flows/ip/ip_test.go
+++ b/flows/ip/ip_test.go
@@ -205,6 +205,7 @@ func TestHeaders(t *testing.T) {
 				},
 				&layers.IPv4{
 					Version: 4,
+					TTL:     32,
 					SrcIP:   net.ParseIP("1.1.1.1"),
 					DstIP:   net.ParseIP("1.1.1.2"),
 				},
@@ -253,9 +254,10 @@ func TestHeaders(t *testing.T) {
 					EthernetType: layers.EthernetTypeIPv6,
 				},
 				&layers.IPv6{
-					Version: 6,
-					SrcIP:   net.ParseIP("::1"),
-					DstIP:   net.ParseIP("::2"),
+					Version:  6,
+					HopLimit: 32,
+					SrcIP:    net.ParseIP("::1"),
+					DstIP:    net.ParseIP("::2"),
 				},
 			},
 		},


### PR DESCRIPTION
```
* (M) flows/ip/ip.go
  - Add a static TTL for IPv[46] flows that is non-zero.
```

magna being used with IPv[46] today likely causes packet drops due to unset TTL.
