### PR TITLE
Add support for the OTG `GetConfig` RPC.

### DIFF
--- a/lwotg/lwotg.go
+++ b/lwotg/lwotg.go
@@ -13,6 +13,7 @@ import (
 	"github.com/openconfig/magna/intf"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/types/known/emptypb"
 	"k8s.io/klog/v2"
 )
 
@@ -180,6 +181,17 @@ func (s *Server) SetConfig(ctx context.Context, req *otg.SetConfigRequest) (*otg
 	s.cfg = req.Config
 
 	return &otg.SetConfigResponse{}, nil
+}
+
+// GetConfig retrieves the current OTG configuration from the lwotg instance, implementing the GetConfig
+// RPC.
+func (s *Server) GetConfig(_ context.Context, req *emptypb.Empty) (*otg.GetConfigResponse, error) {
+	if s.cfg == nil {
+		return nil, status.Errorf(codes.NotFound, "no configuration has been specified")
+	}
+	return &otg.GetConfigResponse{
+		Config: s.cfg,
+	}, nil
 }
 
 // setTrafficGenFns sets the functions that will be used to generate traffic

--- a/lwotg/lwotg.go
+++ b/lwotg/lwotg.go
@@ -185,7 +185,7 @@ func (s *Server) SetConfig(ctx context.Context, req *otg.SetConfigRequest) (*otg
 
 // GetConfig retrieves the current OTG configuration from the lwotg instance, implementing the GetConfig
 // RPC.
-func (s *Server) GetConfig(_ context.Context, req *emptypb.Empty) (*otg.GetConfigResponse, error) {
+func (s *Server) GetConfig(_ context.Context, _ *emptypb.Empty) (*otg.GetConfigResponse, error) {
 	if s.cfg == nil {
 		return nil, status.Errorf(codes.NotFound, "no configuration has been specified")
 	}


### PR DESCRIPTION
```
* (M) lwotg/lwotg(_test)?.go
   - This change adds support for the `GetConfig` OTG RPC, which simply
     returns the current configuration.
```
